### PR TITLE
Persist crouch and walk state in server

### DIFF
--- a/server.py
+++ b/server.py
@@ -486,7 +486,11 @@ class LaserTagServer:
         crouch = bool(inp.get("crouch", False))
         jump_pressed = bool(inp.get("jump", False))
 
-        speed = self._movement_speed(p, walk, crouch)
+        # Persist walking/crouching state so other systems and clients see it
+        p.walking = walk
+        p.crouching = crouch
+
+        speed = self._movement_speed(p, p.walking, p.crouching)
         mx = float(inp.get("mx", 0.0))
         mz = float(inp.get("mz", 0.0))
 


### PR DESCRIPTION
## Summary
- track crouch and walk states from player input
- compute movement speed using these persisted states

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0ab9c4220832aa136c618dd2ae312