### PR TITLE
Improve client interpolation and lag-compensated hitscan

### DIFF
--- a/client.py
+++ b/client.py
@@ -5,7 +5,7 @@ from bisect import bisect, bisect_right
 
 from direct.showbase.ShowBase import ShowBase
 from direct.gui.OnscreenText import OnscreenText
-from panda3d.core import Vec3, Point3, DirectionalLight, AmbientLight, LVector3f, KeyboardButton, WindowProperties
+from panda3d.core import Vec3, Point3, DirectionalLight, AmbientLight, LVector3f, KeyboardButton, WindowProperties, ClockObject
 from panda3d.core import LColor, MouseButton, LineSegs, TextNode
 from panda3d.core import TextNode, TransparencyAttrib, NodePath, LVecBase4f
 from panda3d.core import CompassEffect, BillboardEffect, LColor
@@ -320,7 +320,7 @@ def _angle_lerp_deg(a: float, b: float, t: float) -> float:
 
 
 class GameApp(ShowBase):
-    def __init__(self, cfg, host: str, port: int, name: str, interp_delay: float):
+    def __init__(self, cfg, host: str, port: int, name: str, interp_delay: float, interp_predict: float = 0.0):
         ShowBase.__init__(self)
         self.set_background_color(0.05, 0.05, 0.07, 1)
         self.disableMouse()
@@ -342,7 +342,9 @@ class GameApp(ShowBase):
         self.snap_times: List[float] = []
         self.latest_server_time: float = 0.0
         self.interp_delay: float = max(0.0, float(interp_delay))
-        print(f"[init] Interp delay = {int(self.interp_delay * 1000)} ms")
+        self.interp_predict: float = max(0.0, float(interp_predict))
+        print(f"[init] Interp delay = {int(self.interp_delay * 1000)} ms, predict = {int(self.interp_predict*1000)} ms")
+        self.render_time: float = 0.0
 
         # lighting
         dlight = DirectionalLight("dlight")
@@ -521,12 +523,12 @@ class GameApp(ShowBase):
         """
         if not self.snapshots:
             return None, None, 0.0
-        if len(self.snapshots) == 1 or self.interp_delay <= 1e-6:
-            # No buffering or only one snapshot: render as-is.
+        if len(self.snapshots) == 1:
+            # Only one snapshot: render as-is.
             s = self.snapshots[-1]
             return s, s, 0.0
 
-        render_time = self.latest_server_time - self.interp_delay
+        render_time = self.render_time
 
         # Find index i such that snap_times[i] <= render_time < snap_times[i+1]
         i = bisect_right(self.snap_times, render_time) - 1
@@ -570,7 +572,7 @@ class GameApp(ShowBase):
         thickness = float(vis.get("beam_thickness_px", 3.0))
 
         # Render clock (server-time) that our interpolation already uses
-        render_time = self.latest_server_time - self.interp_delay  # same clock as get_snapshots_for_render()
+        render_time = self.render_time  # same clock as get_snapshots_for_render()
 
         col_red  = self.cfg["colors"]["team_red"]
         col_blue = self.cfg["colors"]["team_blue"]
@@ -681,6 +683,13 @@ class GameApp(ShowBase):
         self._layout_killfeed()
 
     def update_task(self, task):
+        # advance smoothed render_time toward latest snapshot time
+        target = self.latest_server_time - self.interp_delay + self.interp_predict
+        dt = ClockObject.getGlobalClock().getDt()
+        if self.render_time == 0.0:
+            self.render_time = target
+        else:
+            self.render_time = min(target, self.render_time + dt)
         # === Interpolate and render ===
         s0, s1, a = self._get_interp_pair()
 
@@ -855,6 +864,7 @@ class GameApp(ShowBase):
 
         if self.mouseWatcherNode.is_button_down(MouseButton.one()):
             data["fire"] = True
+            data["fire_t"] = self.render_time
 
         if self.client.writer:
             self.net_runner.run_coro(self.client.send_input(data))
@@ -883,6 +893,12 @@ def main():
         default=0.10,
         help="Seconds of render-time interpolation delay buffer (e.g., 0.10 = 100 ms)",
     )
+    ap.add_argument(
+        "--interp_predict",
+        type=float,
+        default=0.0,
+        help="Seconds of render-time prediction/extrapolation",
+    )
     args = ap.parse_args()
     cfg = load_config(args.config)
 
@@ -895,7 +911,7 @@ def main():
     if not port:
         port = cfg["server"]["port"]
 
-    app = GameApp(cfg, host=host, port=port, name=args.name, interp_delay=args.interp_delay)
+    app = GameApp(cfg, host=host, port=port, name=args.name, interp_delay=args.interp_delay, interp_predict=args.interp_predict)
     app.run()
 
 

--- a/server.py
+++ b/server.py
@@ -2,6 +2,7 @@
 # Bullet ray tests for lasers, safe-spawn, auto-unstick, and shared solid collide-mask fix.
 import asyncio, json, math, time, random, argparse, signal
 from typing import Dict, Any, List, Tuple, Optional
+from bisect import bisect_right
 
 from common.net import read_json, send_json, lan_discovery_server
 from game.constants import (
@@ -60,6 +61,7 @@ class LaserTagServer:
         self.inputs: Dict[int, Dict[str, Any]] = {}
         self.bot_brains: Dict[int, SimpleBotBrain] = {}
         self.recent_beams: List[Dict[str, Any]] = []
+        self._state_history: List[Tuple[float, Dict[int, Tuple[float,float,float]]]] = []
 
         # ---- Bullet world ----
         self._root = NodePath("world")
@@ -331,6 +333,44 @@ class LaserTagServer:
                 fl.x, fl.y, fl.z = fx, fy, fz
                 print(f"[score] Team {'RED' if p.team==TEAM_RED else 'BLUE'} captured! -> {self.gs.teams[p.team].captures}")
 
+    # ---------- Lag-comp history ----------
+    def _record_history(self):
+        snap = {pid: (p.x, p.y, p.z) for pid, p in self.gs.players.items()}
+        t = now()
+        self._state_history.append((t, snap))
+        # keep ~1s of history
+        while self._state_history and t - self._state_history[0][0] > 1.0:
+            self._state_history.pop(0)
+
+    def _positions_at(self, t: float) -> Dict[int, Tuple[float, float, float]]:
+        if not self._state_history:
+            return {pid: (p.x, p.y, p.z) for pid, p in self.gs.players.items()}
+        times = [ts for ts, _ in self._state_history]
+        idx = bisect_right(times, t) - 1
+        if idx < 0:
+            return dict(self._state_history[0][1])
+        if idx >= len(self._state_history) - 1:
+            return dict(self._state_history[-1][1])
+        t0, s0 = self._state_history[idx]
+        t1, s1 = self._state_history[idx + 1]
+        if t1 <= t0:
+            return dict(s1)
+        a = (t - t0) / (t1 - t0)
+        pos = {}
+        keys = set(s0.keys()) | set(s1.keys())
+        for pid in keys:
+            p0 = s0.get(pid)
+            p1 = s1.get(pid)
+            if p0 and p1:
+                pos[pid] = (
+                    (1 - a) * p0[0] + a * p1[0],
+                    (1 - a) * p0[1] + a * p1[1],
+                    (1 - a) * p0[2] + a * p1[2],
+                )
+            else:
+                pos[pid] = p1 or p0
+        return pos
+
     # ---------- Firing / hitscan ----------
     def _add_beam(self, team: int, start: Tuple[float,float,float], end: Tuple[float,float,float]):
         sx, sy, sz = start
@@ -346,7 +386,7 @@ class LaserTagServer:
             "t": now(),             # shot start time
         })
 
-    def _apply_hitscan(self, shooter: "Player", spread_rad: float):
+    def _apply_hitscan(self, shooter: "Player", spread_rad: float, fire_time: Optional[float] = None):
         """
         Fire one hitscan ray with cone spread.
         Returns (victim_pid, hit_point_xyz, dir_xyz) or (None, None, None).
@@ -354,9 +394,12 @@ class LaserTagServer:
         """
         import math, random
 
+        positions = self._positions_at(fire_time) if fire_time is not None else {pid: (p.x, p.y, p.z) for pid, p in self.gs.players.items()}
+
         # Shooter eye position (align with client camera)
         ph = float(self.cfg["gameplay"]["player_height"])
-        sx, sy, sz = shooter.x, shooter.y, shooter.z + 0.30 * ph  # was +0.50
+        sx, sy, sz = positions.get(shooter.pid, (shooter.x, shooter.y, shooter.z))
+        sx, sy, sz = sx, sy, sz + 0.30 * ph  # was +0.50
 
         fx, fy, fz = forward_vector(shooter.yaw_rad, shooter.pitch_rad)
 
@@ -445,7 +488,8 @@ class LaserTagServer:
             if pid == shooter.pid:               continue
             if not v.alive:                      continue
             if (not friendly_fire) and (v.team == shooter.team):  continue
-            t = hit_t_for_aabb(v.x, v.y, v.z, hx, hy, hz)
+            vx, vy, vz = positions.get(pid, (v.x, v.y, v.z))
+            t = hit_t_for_aabb(vx, vy, vz, hx, hy, hz)
             if t is not None and (t_player is None or t < t_player):
                 t_player, victim_pid = t, pid
 
@@ -524,7 +568,8 @@ class LaserTagServer:
                 hit_pt = None
                 shot_dir = None
 
-                res = self._apply_hitscan(p, spread_rad)
+                fire_t = float(inp.get("fire_t", now()))
+                res = self._apply_hitscan(p, spread_rad, fire_time=fire_t)
                 if isinstance(res, tuple) and len(res) == 3:
                     victim_pid, hit_pt, shot_dir = res
                 elif isinstance(res, int):
@@ -941,6 +986,7 @@ class LaserTagServer:
             # Sync physics → game state, then unstick
             self._after_physics_sync()
             self._auto_unstick(tick_dt)
+            self._record_history()
 
             # Interactions
             for pid, p in self.gs.players.items():


### PR DESCRIPTION
## Summary
- smooth client render time with optional prediction and expose `--interp_predict`
- include shot timestamp in inputs for lag-compensated hitscan
- track recent server positions to rewind player locations when resolving hitscan
- advance client render clock using Panda3D frame delta to remove multi-second input delay

## Testing
- `python -m py_compile client.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0ac4b1448832a8b46e0a99811c020