### PR TITLE
Add grenade throwing mechanic with blast elimination

### DIFF
--- a/configs/defaults.json
+++ b/configs/defaults.json
@@ -21,14 +21,21 @@
     "gravity": 9.81,
     "player_height": 2.0,
     "player_radius": 0.5,
-    "arena_size_m": [160.0, 50.0],
+    "arena_size_m": [
+      160.0,
+      50.0
+    ],
     "rapid_fire_rate_hz": 10.0,
     "recoil_per_shot_deg": 0.4,
     "recoil_decay_per_sec_deg": 5.0,
     "base_spread_deg": 0.15,
     "spread_move_factor": 0.7,
     "spread_crouch_bonus": -0.08,
-    "laser_range_m": 200.0
+    "laser_range_m": 200.0,
+    "grenade_max_charge": 1.5,
+    "grenade_throw_speed": 20.0,
+    "grenade_fuse": 3.0,
+    "grenade_radius": 5.0
   },
   "cubes": {
     "size": 1.0,
@@ -127,22 +134,77 @@
     },
     "headgear": {
       "enabled": true,
-      "default": { "type": "ballcap", "color": "purple" },
-      "palette": {
-        "red":     [1.0, 0.25, 0.25, 1.0],
-        "green":   [0.30, 1.0, 0.30, 1.0],
-        "yellow":  [1.0, 0.92, 0.25, 1.0],
-        "purple":  [0.62, 0.35, 1.0, 1.0],
-        "teal":    [0.25, 1.0, 1.0, 1.0],
-        "magenta": [1.0, 0.35, 0.85, 1.0],
-        "white":   [1.0, 1.0, 1.0, 1.0],
-        "black":   [0.12, 0.12, 0.12, 1.0]
+      "default": {
+        "type": "ballcap",
+        "color": "purple"
       },
-      "disallow_colors": ["blue", "orange"],
+      "palette": {
+        "red": [
+          1.0,
+          0.25,
+          0.25,
+          1.0
+        ],
+        "green": [
+          0.3,
+          1.0,
+          0.3,
+          1.0
+        ],
+        "yellow": [
+          1.0,
+          0.92,
+          0.25,
+          1.0
+        ],
+        "purple": [
+          0.62,
+          0.35,
+          1.0,
+          1.0
+        ],
+        "teal": [
+          0.25,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "magenta": [
+          1.0,
+          0.35,
+          0.85,
+          1.0
+        ],
+        "white": [
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "black": [
+          0.12,
+          0.12,
+          0.12,
+          1.0
+        ]
+      },
+      "disallow_colors": [
+        "blue",
+        "orange"
+      ],
       "assignments": {
-        "Mike":   { "type": "ballcap", "color": "purple" },
-        "BotR1":  { "type": "headband", "color": "yellow" },
-        "BotB1":  { "type": "top_hat",  "color": "teal" }
+        "Mike": {
+          "type": "ballcap",
+          "color": "purple"
+        },
+        "BotR1": {
+          "type": "headband",
+          "color": "yellow"
+        },
+        "BotB1": {
+          "type": "top_hat",
+          "color": "teal"
+        }
       }
     },
     "anchors": {


### PR DESCRIPTION
## Summary
- Add throwable grenades that charge throw distance and explode after a fuse
- Grenades update on the authoritative server and eliminate nearby enemies with knockback
- Client supports right‑mouse grenade throws and renders active grenades
- Ensure grenade throw inputs aren’t lost between frames and log spawn events for debugging

## Testing
- `python -m py_compile server.py client.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0b3905ac4832aa3e56ba383a562c7