### PR TITLE
Add grenade throwing mechanic with blast elimination

### DIFF
--- a/client.py
+++ b/client.py
@@ -400,6 +400,9 @@ class GameApp(ShowBase):
 
         # player representations
         self.player_nodes = {}  # pid -> NodePath
+        self.grenade_nodes = {}  # gid -> NodePath
+        self._grenade_hold_start = None
+        self.explosion_nodes = []  # list of {"node": NodePath, "expire": float}
 
         # cosmetics
         self.local_team = None  # filled post-handshake
@@ -770,6 +773,42 @@ class GameApp(ShowBase):
                 self.player_nodes[pid].removeNode()
                 del self.player_nodes[pid]
 
+        # --- Grenades ---
+        g_present = set()
+        latest = s1 or s0
+        if latest:
+            for g in latest.get("grenades", []):
+                gid = g.get("id")
+                node = self.grenade_nodes.get(gid)
+                if node is None:
+                    node = self.loader.loadModel("models/box")
+                    node.setScale(0.4)
+                    col = (1, 0, 0, 1) if g.get("team") == TEAM_RED else (0, 0, 1, 1)
+                    node.setColor(*col)
+                    node.reparentTo(self.render)
+                    self.grenade_nodes[gid] = node
+                node.setPos(g.get("x",0.0), g.get("y",0.0), g.get("z",0.0))
+                g_present.add(gid)
+        for gid in list(self.grenade_nodes.keys()):
+            if gid not in g_present:
+                self.grenade_nodes[gid].removeNode()
+                del self.grenade_nodes[gid]
+
+
+        if latest:
+            for e in latest.get("explosions", []):
+                node = self.loader.loadModel("models/box")
+                radius = float(self.cfg.get("gameplay", {}).get("grenade_radius", 5.0))
+                node.setScale(radius)
+                node.setColor(1, 0.5, 0, 0.7)
+                node.setTransparency(TransparencyAttrib.M_alpha)
+                node.setPos(e.get("x",0.0), e.get("y",0.0), e.get("z",0.0))
+                node.reparentTo(self.render)
+                self.explosion_nodes.append({"node": node, "expire": self.render_time + 0.3})
+        for ent in list(self.explosion_nodes):
+            if self.render_time >= ent["expire"]:
+                ent["node"].removeNode()
+                self.explosion_nodes.remove(ent)
 
         # Smooth camera **position** using our interpolated "me" (orientation from live mouse)
         if my_pid is not None:
@@ -865,6 +904,15 @@ class GameApp(ShowBase):
         if self.mouseWatcherNode.is_button_down(MouseButton.one()):
             data["fire"] = True
             data["fire_t"] = self.render_time
+
+        # Middle mouse for grenade throw
+        if self.mouseWatcherNode.is_button_down(MouseButton.two()):
+            if self._grenade_hold_start is None:
+                self._grenade_hold_start = self.render_time
+        elif self._grenade_hold_start is not None:
+            hold = max(0.0, self.render_time - self._grenade_hold_start)
+            data["grenade"] = hold
+            self._grenade_hold_start = None
 
         if self.client.writer:
             self.net_runner.run_coro(self.client.send_input(data))

--- a/configs/defaults.json
+++ b/configs/defaults.json
@@ -21,14 +21,21 @@
     "gravity": 9.81,
     "player_height": 2.0,
     "player_radius": 0.5,
-    "arena_size_m": [160.0, 50.0],
+    "arena_size_m": [
+      160.0,
+      50.0
+    ],
     "rapid_fire_rate_hz": 10.0,
     "recoil_per_shot_deg": 0.4,
     "recoil_decay_per_sec_deg": 5.0,
     "base_spread_deg": 0.15,
     "spread_move_factor": 0.7,
     "spread_crouch_bonus": -0.08,
-    "laser_range_m": 200.0
+    "laser_range_m": 200.0,
+    "grenade_max_charge": 1.5,
+    "grenade_throw_speed": 20.0,
+    "grenade_fuse": 3.0,
+    "grenade_radius": 5.0
   },
   "cubes": {
     "size": 1.0,
@@ -127,22 +134,77 @@
     },
     "headgear": {
       "enabled": true,
-      "default": { "type": "ballcap", "color": "purple" },
-      "palette": {
-        "red":     [1.0, 0.25, 0.25, 1.0],
-        "green":   [0.30, 1.0, 0.30, 1.0],
-        "yellow":  [1.0, 0.92, 0.25, 1.0],
-        "purple":  [0.62, 0.35, 1.0, 1.0],
-        "teal":    [0.25, 1.0, 1.0, 1.0],
-        "magenta": [1.0, 0.35, 0.85, 1.0],
-        "white":   [1.0, 1.0, 1.0, 1.0],
-        "black":   [0.12, 0.12, 0.12, 1.0]
+      "default": {
+        "type": "ballcap",
+        "color": "purple"
       },
-      "disallow_colors": ["blue", "orange"],
+      "palette": {
+        "red": [
+          1.0,
+          0.25,
+          0.25,
+          1.0
+        ],
+        "green": [
+          0.3,
+          1.0,
+          0.3,
+          1.0
+        ],
+        "yellow": [
+          1.0,
+          0.92,
+          0.25,
+          1.0
+        ],
+        "purple": [
+          0.62,
+          0.35,
+          1.0,
+          1.0
+        ],
+        "teal": [
+          0.25,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "magenta": [
+          1.0,
+          0.35,
+          0.85,
+          1.0
+        ],
+        "white": [
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "black": [
+          0.12,
+          0.12,
+          0.12,
+          1.0
+        ]
+      },
+      "disallow_colors": [
+        "blue",
+        "orange"
+      ],
       "assignments": {
-        "Mike":   { "type": "ballcap", "color": "purple" },
-        "BotR1":  { "type": "headband", "color": "yellow" },
-        "BotB1":  { "type": "top_hat",  "color": "teal" }
+        "Mike": {
+          "type": "ballcap",
+          "color": "purple"
+        },
+        "BotR1": {
+          "type": "headband",
+          "color": "yellow"
+        },
+        "BotB1": {
+          "type": "top_hat",
+          "color": "teal"
+        }
       }
     },
     "anchors": {

--- a/server.py
+++ b/server.py
@@ -17,7 +17,7 @@ from game.bot_ai import SimpleBotBrain
 
 # --- Panda3D / Bullet (headless) ---
 from panda3d.core import Vec3, Point3, NodePath, BitMask32, LPoint3
-from panda3d.bullet import BulletWorld, BulletRigidBodyNode, BulletBoxShape, BulletCharacterControllerNode
+from panda3d.bullet import BulletWorld, BulletRigidBodyNode, BulletBoxShape, BulletCharacterControllerNode, BulletSphereShape
 # ---------- Config ----------
 def load_config(path: str) -> Dict[str, Any]:
     with open(path, "r") as f:
@@ -75,6 +75,11 @@ class LaserTagServer:
         self._corpse_np: Dict[int, NodePath] = {}
         self._corpse_node: Dict[int, "BulletRigidBodyNode"] = {}
         self._last_hitinfo: Dict[int, Tuple[Tuple[float,float,float], Tuple[float,float,float]]] = {}
+
+        # Grenade state
+        self._grenades: Dict[int, Dict[str, Any]] = {}  # gid -> {owner, np, node, explode_at}
+        self._next_gid: int = 1
+        self._recent_explosions: List[Tuple[float,float,float]] = []
 
         # Unstick state
         self._last_pos: Dict[int, Tuple[float,float,float]] = {}
@@ -511,7 +516,56 @@ class LaserTagServer:
         dlen = math.sqrt(fx*fx + fy*fy + fz*fz) or 1.0
         return victim_pid, hit_point, (fx/dlen, fy/dlen, fz/dlen)
 
-    # ---------- Input & per-tick ----------
+    
+    def _spawn_grenade(self, owner: Player, power: float):
+        gid = self._next_gid
+        self._next_gid += 1
+        radius = 0.2
+        shape = BulletSphereShape(radius)
+        node = BulletRigidBodyNode(f"grenade-{gid}")
+        node.setMass(1.0)
+        node.addShape(shape)
+        node.setFriction(0.5)
+        node.setRestitution(0.6)
+        node.setIntoCollideMask(MASK_SOLID)
+        np = self._root.attachNewNode(node)
+        np.setPos(owner.x, owner.y, owner.z + 1.0)
+        self.world.attachRigidBody(node)
+        fx, fy, fz = forward_vector(owner.yaw_rad, owner.pitch_rad)
+        base = float(self.cfg["gameplay"].get("grenade_throw_speed", 15.0))
+        max_charge = float(self.cfg["gameplay"].get("grenade_max_charge", 1.5))
+        speed = base * min(1.0, power / max_charge)
+        owner_vel = Vec3(owner.vx, owner.vy, owner.vz)
+        node.setLinearVelocity(Vec3(fx*speed, fy*speed, fz*speed + 5.0) + owner_vel)
+        fuse = float(self.cfg["gameplay"].get("grenade_fuse", 3.0))
+        self._grenades[gid] = {"owner": owner.pid, "np": np, "node": node, "explode_at": now() + fuse}
+        print(f'[grenade] spawn gid={gid} owner={owner.pid} power={power:.2f}')
+
+    def _update_grenades(self):
+        radius = float(self.cfg["gameplay"].get("grenade_radius", 5.0))
+        tnow = now()
+        remove = []
+        for gid, g in list(self._grenades.items()):
+            if tnow >= g["explode_at"]:
+                pos = g["np"].getPos()
+                for pid, pl in self.gs.players.items():
+                    if not pl.alive or pid == g["owner"]:
+                        continue
+                    thrower = self.gs.players.get(g["owner"])
+                    if thrower and pl.team == thrower.team:
+                        continue
+                    dx, dy, dz = pl.x - pos.x, pl.y - pos.y, pl.z - pos.z
+                    dist = (dx*dx + dy*dy + dz*dz) ** 0.5
+                    if dist <= radius:
+                        self._tag_player(pid, attacker=g["owner"], hit_point=(pl.x, pl.y, pl.z), shot_dir=(dx, dy, dz))
+                        print(f'[grenade] kill gid={gid} victim={pid} by={g["owner"]}')
+                self._recent_explosions.append((float(pos.x), float(pos.y), float(pos.z)))
+                self.world.removeRigidBody(g["node"])
+                g["np"].removeNode()
+                remove.append(gid)
+        for gid in remove:
+            del self._grenades[gid]
+# ---------- Input & per-tick ----------
     def _movement_speed(self, p: Player, walk: bool, crouch: bool) -> float:
         if crouch:
             return float(self.cfg["gameplay"]["crouch_speed"])
@@ -555,6 +609,11 @@ class LaserTagServer:
                 ch.doJump()
             except Exception:
                 pass
+
+        power = float(inp.get("grenade", 0.0))
+        if power > 0.0:
+            self._spawn_grenade(p, power)
+            inp["grenade"] = 0.0
 
         if bool(inp.get("fire", False)):
             t = now()
@@ -740,11 +799,16 @@ class LaserTagServer:
                 self._stuck_since[pid] = 0.0
 
     def _after_physics_sync(self):
-        # Alive players: sync from character controller nodes (unchanged)
+        tick_dt = 1.0 / float(self.cfg["server"]["tick_hz"])
+
+        # Alive players: sync from character controller nodes and record velocity
         for pid, p in self.gs.players.items():
             np = self._char_np.get(pid)
             if np is not None:
                 pos = np.getPos()
+                p.vx = (float(pos.x) - p.x) / tick_dt
+                p.vy = (float(pos.y) - p.y) / tick_dt
+                p.vz = (float(pos.z) - p.z) / tick_dt
                 p.x, p.y, p.z = float(pos.x), float(pos.y), float(pos.z)
                 try:
                     p.on_ground = bool(self._char_node[pid].isOnGround())
@@ -759,6 +823,9 @@ class LaserTagServer:
             if np is None:
                 continue
             pos = np.getPos()
+            p.vx = (float(pos.x) - p.x) / tick_dt
+            p.vy = (float(pos.y) - p.y) / tick_dt
+            p.vz = (float(pos.z) - p.z) / tick_dt
             p.x, p.y, p.z = float(pos.x), float(pos.y), float(pos.z)
 
         # Lightweight player-player separation for KCCs
@@ -842,6 +909,15 @@ class LaserTagServer:
                 "x": fl.x, "y": fl.y, "z": fl.z
             })
         
+        grenades = []
+        for gid, g in self._grenades.items():
+            pos = g['np'].getPos()
+            player = self.gs.players.get(g["owner"])
+            team = player.team if player else TEAM_RED
+            grenades.append({"id": gid, "team": team, "x": float(pos.x), "y": float(pos.y), "z": float(pos.z)})
+
+        explosions = [{"x": x, "y": y, "z": z} for (x, y, z) in self._recent_explosions]
+        self._recent_explosions.clear()
         now_t = now()
         hud_cfg = self.cfg.get("hud", {})
         ttl = float(hud_cfg.get("killfeed_ttl", 4.0))
@@ -854,6 +930,8 @@ class LaserTagServer:
             "time": now(),
             "players": players,
             "flags": flags,
+            "grenades": grenades,
+            "explosions": explosions,
             "teams": {TEAM_RED: {"captures": self.gs.teams[TEAM_RED].captures},
                       TEAM_BLUE: {"captures": self.gs.teams[TEAM_BLUE].captures}},
             "match_over": self.gs.match_over,
@@ -883,7 +961,10 @@ class LaserTagServer:
                 if not msg:
                     break
                 if msg.get("type") == "input":
-                    self.inputs[pid] = msg.get("data", {})
+                    data = msg.get("data", {})
+                    current = self.inputs.get(pid, {})
+                    current.update(data)
+                    self.inputs[pid] = current
         except Exception as e:
             print(f"[client] {addr} error: {e}")
         finally:
@@ -989,6 +1070,7 @@ class LaserTagServer:
 
             # Sync physics → game state, then unstick
             self._after_physics_sync()
+            self._update_grenades()
             self._auto_unstick(tick_dt)
             self._record_history()
 


### PR DESCRIPTION
## Summary
- Inherit player velocity when spawning grenades and track velocities server-side
- Color grenades by team, report explosions, and log grenade eliminations
- Render team-colored grenades, display explosion effect, and document middle-mouse throws

## Testing
- `python -m py_compile server.py client.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0b3905ac4832aa3e56ba383a562c7