### PR TITLE
Add interactive leaderboard with player stats

### DIFF
--- a/client.py
+++ b/client.py
@@ -12,6 +12,7 @@ from panda3d.core import CompassEffect, BillboardEffect, LColor
 
 from common.net import send_json, read_json, lan_discovery_broadcast
 from game.constants import TEAM_RED, TEAM_BLUE
+from scoreboard import Scoreboard
 from game.map_gen import generate
 
 # ========== Cosmetics Manager ==========
@@ -307,7 +308,7 @@ class NetworkClient:
 
     async def send_input(self, data: Dict[str, Any]):
         self.last_input = data
-        await send_json(self.writer, {"type": "input", "data": data})
+        await send_json(self.writer, {"type": "input", "time": time.time(), "data": data})
 
 
 def _angle_lerp_deg(a: float, b: float, t: float) -> float:
@@ -424,6 +425,7 @@ class GameApp(ShowBase):
 
         self._kill_seen = set()            # (t_ms, attacker_pid, victim_pid)
         self._kill_nodes = []              # list[(OnscreenText, created_time)]
+        self.scoreboard = Scoreboard(self)
 
         # key state
         self.keys = set()
@@ -872,6 +874,11 @@ class GameApp(ShowBase):
         if self._kill_nodes:
             self._layout_killfeed()
 
+        if "tab" in self.keys:
+            self.scoreboard.show()
+            self.scoreboard.update(self.client.state)
+        else:
+            self.scoreboard.hide()
         # === Build & send inputs ===
         mx = 0.0
         mz = 0.0

--- a/game/server_state.py
+++ b/game/server_state.py
@@ -26,6 +26,12 @@ class Player:
     carrying_flag: Optional[int] = None  # 0 red flag, 1 blue flag (team id)
     last_fire_time: float = 0.0
     recoil_accum: float = 0.0
+    # --- Stats for scoreboard ---
+    tags: int = 0
+    outs: int = 0
+    captures: int = 0
+    defences: int = 0
+    ping_ms: float = 0.0
 
 @dataclass
 class Flag:

--- a/scoreboard.py
+++ b/scoreboard.py
@@ -1,0 +1,94 @@
+from panda3d.core import LColor
+from direct.gui.OnscreenText import OnscreenText
+from panda3d.core import TextNode
+from game.constants import TEAM_RED, TEAM_BLUE
+
+class Scoreboard:
+    def __init__(self, app):
+        self.app = app
+        colors = app.cfg.get("colors", {})
+        self.team_colors = {
+            TEAM_RED: LColor(*colors.get("team_red", (1, 0, 0, 1))),
+            TEAM_BLUE: LColor(*colors.get("team_blue", (0, 0, 1, 1))),
+        }
+        self.visible = False
+        self.nodes = []
+
+    def show(self):
+        self.visible = True
+
+    def hide(self):
+        if not self.visible:
+            return
+        self.visible = False
+        for n in self.nodes:
+            n.removeNode()
+        self.nodes.clear()
+
+    def update(self, state):
+        if not self.visible:
+            return
+        for n in self.nodes:
+            n.removeNode()
+        self.nodes.clear()
+        if not state:
+            return
+        players = state.get("players", [])
+        teams = state.get("teams", {})
+        by_team = {TEAM_RED: [], TEAM_BLUE: []}
+        for p in players:
+            by_team.setdefault(p.get("team"), []).append(p)
+        by_team[TEAM_RED].sort(key=lambda x: x.get("tags", 0), reverse=True)
+        by_team[TEAM_BLUE].sort(key=lambda x: x.get("tags", 0), reverse=True)
+        y = 0.9
+        line = 0.06
+        base_x = -1.2
+        header = OnscreenText(
+            "Name", pos=(base_x, y), align=TextNode.ALeft, fg=(1, 1, 1, 1), scale=0.045
+        )
+        header_stats = OnscreenText(
+            "Ping  Tags  Outs  Cap  Def",
+            pos=(base_x + 0.6, y),
+            align=TextNode.ALeft,
+            fg=(1, 1, 1, 1),
+            scale=0.045,
+        )
+        self.nodes.extend([header, header_stats])
+        y -= line
+        for team in (TEAM_RED, TEAM_BLUE):
+            tname = "RED" if team == TEAM_RED else "BLUE"
+            points = teams.get(team, {}).get("captures", 0)
+            team_line = OnscreenText(
+                f"{tname} - {points}",
+                pos=(base_x, y),
+                align=TextNode.ALeft,
+                fg=self.team_colors[team],
+                scale=0.05,
+            )
+            self.nodes.append(team_line)
+            y -= line
+            for p in by_team.get(team, []):
+                name_color = self.team_colors[team]
+                bg = (1, 1, 1, 0.2) if p.get("pid") == self.app.client.pid else (0, 0, 0, 0)
+                name_node = OnscreenText(
+                    p.get("name", "?"),
+                    pos=(base_x, y),
+                    align=TextNode.ALeft,
+                    fg=name_color,
+                    bg=bg,
+                    scale=0.045,
+                )
+                stat_txt = (
+                    f"{p.get('ping',0):>4} {p.get('tags',0):>4} {p.get('outs',0):>4} "
+                    f"{p.get('captures',0):>4} {p.get('defences',0):>4}"
+                )
+                stat_node = OnscreenText(
+                    stat_txt,
+                    pos=(base_x + 0.6, y),
+                    align=TextNode.ALeft,
+                    fg=(1, 1, 1, 1),
+                    scale=0.045,
+                )
+                self.nodes.extend([name_node, stat_node])
+                y -= line
+            y -= line * 0.5

--- a/server.py
+++ b/server.py
@@ -286,6 +286,7 @@ class LaserTagServer:
                     fx, fy, fz = (self.mapdata.red_flag_stand if fl.team == TEAM_RED else self.mapdata.blue_flag_stand)
                     fl.x, fl.y, fl.z = fx, fy, fz
                     fl.dropped_at_time = 0.0
+                    p.defences += 1
                 continue
 
             if fl.carried_by is not None:
@@ -335,6 +336,7 @@ class LaserTagServer:
             if math.hypot(p.x - bx, p.y - by) <= BASE_CAPTURE_RADIUS:
                 self.gs.teams[p.team].captures += 1
                 fl.carried_by = None
+                p.captures += 1
                 fl.at_base = True
                 fx, fy, fz = (self.mapdata.red_flag_stand if fl.team == TEAM_RED else self.mapdata.blue_flag_stand)
                 fl.x, fl.y, fl.z = fx, fy, fz
@@ -658,6 +660,11 @@ class LaserTagServer:
         if not v or not v.alive:
             return
 
+        # Stat updates
+        v.outs += 1
+        if attacker is not None and attacker in self.gs.players:
+            self.gs.players[attacker].tags += 1
+
         # Mark dead + schedule respawn (unchanged)
         v.alive = False
         v.respawn_at = now() + float(self.cfg["server"]["respawn_seconds"])
@@ -892,6 +899,7 @@ class LaserTagServer:
                 "pid": p.pid, "name": p.name, "team": p.team,
                 "x": p.x, "y": p.y, "z": p.z,
                 "alive": p.alive,
+                "tags": p.tags, "outs": p.outs, "captures": p.captures, "defences": p.defences, "ping": int(p.ping_ms)
             }
             if p.alive:
                 d["yaw"]   = rad_to_deg(p.yaw_rad)
@@ -972,6 +980,10 @@ class LaserTagServer:
                     current = self.inputs.get(pid, {})
                     current.update(data)
                     self.inputs[pid] = current
+                    p = self.gs.players.get(pid)
+                    t = msg.get("time")
+                    if p is not None and t is not None:
+                        p.ping_ms = max(0.0, (now() - float(t)) * 1000.0)
         except Exception as e:
             print(f"[client] {addr} error: {e}")
         finally:


### PR DESCRIPTION
## Summary
- track tags, outs, captures, defences and ping on the server and expose them in snapshots
- send client timestamp and show team-sorted scoreboard when Tab is pressed
- implement standalone scoreboard overlay with team colours and player highlight

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0d3048df8832a917b3b641b0adf9a