### PR TITLE
Remove unused audio and crouch settings from configuration files

### DIFF
--- a/configs/client_settings.json
+++ b/configs/client_settings.json
@@ -2,64 +2,74 @@
   "profile": {
     "name": "PlayerOne",
     "team_preference": "auto",
-    "headgear": { "type": "ballcap", "color": "purple" }
+    "headgear": {
+      "type": "ballcap",
+      "color": "purple"
+    }
   },
-
   "controls": {
     "mouse_sensitivity": 0.12,
     "invert_y": false,
-    "fov": 85,
-    "toggle_crouch": false
+    "fov": 85
   },
-
   "network": {
-    "server": { "host": "auto", "port": 50007 },
+    "server": {
+      "host": "auto",
+      "port": 50007
+    },
     "discovery": {
       "enabled": true,
-      "preferred_server_names": ["Game Night A", "Basement Box"],
+      "preferred_server_names": [
+        "Game Night A",
+        "Basement Box"
+      ],
       "retry_ms": 1200
     },
     "interp_delay": 0.0
   },
-
   "video": {
     "fullscreen": false,
-    "resolution": [1280, 720],
+    "resolution": [
+      1280,
+      720
+    ],
     "vsync": false,
     "max_fps": 120,
     "render_distance": 120.0,
     "show_fps": true,
     "hud_scale": 1.0
   },
-
-  "audio": {
-    "master": 0.8,
-    "effects": 1.0,
-    "music": 0.3,
-    "device": "default",
-    "muted": false
-  },
-
   "cosmetics": {
-    "nameplates": { "enabled": true, "for": "team_only", "max_distance": 45, "fade_start": 30, "scale": 0.55 },
-    "teammate_marker": { "enabled": true, "alpha": 0.9, "max_distance": 70, "fade_start": 40, "scale": 0.6, "style": "chevron" }
+    "nameplates": {
+      "enabled": true,
+      "for": "team_only",
+      "max_distance": 45,
+      "fade_start": 30,
+      "scale": 0.55
+    },
+    "teammate_marker": {
+      "enabled": true,
+      "alpha": 0.9,
+      "max_distance": 70,
+      "fade_start": 40,
+      "scale": 0.6,
+      "style": "chevron"
+    }
   },
-
   "server_prefs": {
     "auto_join_on_match": true,
     "remember_last_server": true
   },
-
   "hardware": {
     "gpu_preference": "high_performance",
-    "thread_pool": { "workers": 4 }
+    "thread_pool": {
+      "workers": 4
+    }
   },
-
   "debug": {
     "netgraph": false,
     "log_level": "info"
   },
-
   "privacy": {
     "send_telemetry": false
   }

--- a/configs/defaults.json
+++ b/configs/defaults.json
@@ -21,8 +21,6 @@
   },
   "gameplay": {
     "run_speed": 7.0,
-    "walk_speed": 5.0,
-    "crouch_speed": 3.0,
     "acceleration_mps2": 60.0,
     "decel_release_mps2": 45.0,
     "decel_counter_mps2": 60.0,
@@ -38,7 +36,6 @@
     "recoil_decay_hz": 7.5,
     "base_spread_deg": 0.15,
     "spread_move_factor": 0.7,
-    "spread_crouch_bonus": -0.08,
     "laser_range_m": 200.0,
     "grenade_max_charge": 1.5,
     "grenade_throw_speed": 30.0,
@@ -95,10 +92,6 @@
     "killfeed_max": 6,
     "killfeed_ttl": 4.0,
     "killfeed_font_scale": 0.045
-  },
-  "audio": {
-    "volume": 0.7,
-    "muted": false
   },
   "controls": {
     "mouse_sensitivity": 0.12,


### PR DESCRIPTION
## Summary
- remove unused audio, walk, and crouch-related gameplay options from the default configuration
- drop audio and crouch toggles from the client settings file to reflect unsupported features

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5a2a12708832a9a180d776e4c456e