### PR TITLE
Make bot engagement range configurable

### DIFF
--- a/configs/defaults.json
+++ b/configs/defaults.json
@@ -16,7 +16,9 @@
       "turn_rates": {
         "idle": 420.0,
         "engaged": 420.0
-      }
+      },
+      "engagement_range_m": 40.0,
+      "target_acquire_range_m": 45.0
     }
   },
   "gameplay": {

--- a/configs/defaults.json
+++ b/configs/defaults.json
@@ -17,8 +17,8 @@
         "idle": 420.0,
         "engaged": 420.0
       },
-      "engagement_range_m": 40.0,
-      "target_acquire_range_m": 45.0
+      "engagement_range_m": 200.0,
+      "target_acquire_range_m": 200.0
     }
   },
   "gameplay": {

--- a/game/bot_ai.py
+++ b/game/bot_ai.py
@@ -356,6 +356,8 @@ class AStarBotBrain:
         radio: BotRadio = RADIO,
         idle_turn_rate_deg: float = 240.0,
         engaged_turn_rate_deg: float = 420.0,
+        engagement_range_m: float = 40.0,
+        target_acquire_range_m: float = 45.0,
     ) -> None:
         self.team = team
         self.base_pos = base_pos
@@ -385,6 +387,9 @@ class AStarBotBrain:
         engaged_deg = max(idle_deg, float(engaged_turn_rate_deg))
         self._turn_rate_idle = math.radians(idle_deg)
         self._turn_rate_engaged = math.radians(engaged_deg)
+        self._engagement_range = max(0.0, float(engagement_range_m))
+        target_range = max(self._engagement_range, float(target_acquire_range_m))
+        self._target_acquire_range = target_range
         self._micro_state: str = ""
         self._micro_target: Optional[Tuple[float, float]] = None
         self._micro_retreat_vec: Optional[Tuple[float, float]] = None
@@ -788,7 +793,7 @@ class AStarBotBrain:
         self,
         me,
         gs,
-        max_range: float = 45.0,
+        max_range: Optional[float] = None,
         require_line: bool = False,
         mapdata=None,
         now: Optional[float] = None,
@@ -797,6 +802,8 @@ class AStarBotBrain:
     ):
         if now is None:
             now = time.time()
+        if max_range is None:
+            max_range = self._target_acquire_range
         best = None
         best_d2 = max_range * max_range
         pool: Iterable
@@ -1259,7 +1266,7 @@ class AStarBotBrain:
         turn_rate = self._turn_rate_idle
         if enemy is not None:
             dist = math.hypot(enemy.x - me.x, enemy.y - me.y)
-            inputs["fire"] = dist <= 40.0
+            inputs["fire"] = dist <= self._engagement_range
             aim_point = (enemy.x, enemy.y)
             turn_rate = self._turn_rate_engaged
         elif self._micro_state == "peek" and self._micro_target:

--- a/server.py
+++ b/server.py
@@ -590,6 +590,10 @@ class LaserTagServer:
             turn_cfg = bot_cfg.get("turn_rates", {})
             idle_turn = float(turn_cfg.get("idle", 240.0))
             engaged_turn = float(turn_cfg.get("engaged", 420.0))
+            engagement_range = float(bot_cfg.get("engagement_range_m", 40.0))
+            target_acquire_range = float(bot_cfg.get("target_acquire_range_m", max(engagement_range, 45.0)))
+            if target_acquire_range < engagement_range:
+                target_acquire_range = engagement_range
 
             brain = AStarBotBrain(
                 team,
@@ -599,6 +603,8 @@ class LaserTagServer:
                 nav_graph=self.nav_graph,
                 idle_turn_rate_deg=idle_turn,
                 engaged_turn_rate_deg=engaged_turn,
+                engagement_range_m=engagement_range,
+                target_acquire_range_m=target_acquire_range,
             )
             self.bot_brains[pid] = brain
 


### PR DESCRIPTION
## Summary
- add configurable engagement and target acquisition ranges for bots in defaults.json
- plumb the new settings into the server so AStarBotBrain instances receive them
- use the configured ranges when selecting targets and deciding when to fire

## Testing
- pytest tests/test_bot_micro.py

------
https://chatgpt.com/codex/tasks/task_e_68e5bf3a2ebc832aaf0295084a56eee3