### PR TITLE
Add round timer draw handling and HUD countdown

### DIFF
--- a/client.py
+++ b/client.py
@@ -2290,7 +2290,7 @@ class GameApp(ShowBase):
         if not isinstance(rounds, dict) or not rounds.get('enabled'):
             self.round_timer_text.setText("")
             self.round_phase_text.setText("")
-            self.round_timer_text.setTextColor(*self._round_timer_base_color)
+            self.round_timer_text.setColor(*self._round_timer_base_color)
             return
 
         phase = str(rounds.get('phase') or '')
@@ -2316,11 +2316,11 @@ class GameApp(ShowBase):
             timer_text = self._format_round_timer(seconds)
             warn = phase in {'neutral', 'secured'} and seconds <= 10.0
             color = self._round_timer_warn_color if warn else self._round_timer_base_color
-            self.round_timer_text.setTextColor(*color)
+            self.round_timer_text.setColor(*color)
             self.round_timer_text.setText(timer_text)
         else:
             self.round_timer_text.setText("")
-            self.round_timer_text.setTextColor(*self._round_timer_base_color)
+            self.round_timer_text.setColor(*self._round_timer_base_color)
 
         if phase == 'complete':
             phase_text = 'Match Complete'

--- a/client.py
+++ b/client.py
@@ -1325,6 +1325,24 @@ class GameApp(ShowBase):
                                  scale=self._kill_scale, max_items=self._kill_max, ttl=self._kill_ttl)
         self.msg_feed  = HudFeed(x=-1.25, y_start=0.92, align=TextNode.ALeft,
                                  scale=self._msg_scale, max_items=self._msg_max, ttl=self._msg_ttl)
+        self.round_timer_text = OnscreenText(
+            text="",
+            pos=(0.0, 0.9),
+            fg=(1, 1, 1, 1),
+            align=TextNode.ACenter,
+            scale=0.08,
+            mayChange=True,
+        )
+        self.round_phase_text = OnscreenText(
+            text="",
+            pos=(0.0, 0.82),
+            fg=(1, 1, 1, 1),
+            align=TextNode.ACenter,
+            scale=0.045,
+            mayChange=True,
+        )
+        self._round_timer_warn_color = (1.0, 0.35, 0.35, 1.0)
+        self._round_timer_base_color = (1.0, 1.0, 1.0, 1.0)
         # Message feed (top-left) — similar policy to killfeed
         self._msg_ttl   = float(hud_cfg.get("messagefeed_ttl", self._kill_ttl))
         self._msg_max   = int(hud_cfg.get("messagefeed_max", self._kill_max))
@@ -2234,6 +2252,95 @@ class GameApp(ShowBase):
         return dx, dy
 
 
+    def _coerce_team_value(self, value) -> Optional[int]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            stripped = value.strip().lower()
+            if stripped in ("", "none"):
+                return None
+            if stripped in (str(TEAM_RED), "red"):
+                return TEAM_RED
+            if stripped in (str(TEAM_BLUE), "blue"):
+                return TEAM_BLUE
+            try:
+                return int(stripped)
+            except ValueError:
+                return None
+        try:
+            return int(value)
+        except Exception:
+            return None
+
+    def _format_round_timer(self, seconds: float) -> str:
+        seconds = max(0.0, float(seconds))
+        minutes = int(seconds // 60)
+        secs = int(seconds % 60)
+        if minutes > 0:
+            return f"{minutes}:{secs:02d}"
+        if seconds >= 10.0:
+            return f"{int(seconds):02d}"
+        tenths = int((seconds - secs) * 10)
+        tenths = max(0, min(9, tenths))
+        return f"{secs:02d}.{tenths}"
+
+    def _update_round_hud(self, snapshot: Optional[Dict[str, Any]]) -> None:
+        hud = snapshot.get('hud') if snapshot else None
+        rounds = hud.get('rounds') if isinstance(hud, dict) else None
+        if not isinstance(rounds, dict) or not rounds.get('enabled'):
+            self.round_timer_text.setText("")
+            self.round_phase_text.setText("")
+            self.round_timer_text.setTextColor(*self._round_timer_base_color)
+            return
+
+        phase = str(rounds.get('phase') or '')
+        round_no = rounds.get('round')
+        try:
+            round_no = int(round_no)
+        except Exception:
+            round_no = None
+
+        intermission_remaining = float(rounds.get('intermission_remaining', 0.0) or 0.0)
+        hold_remaining = float(rounds.get('hold_remaining', 0.0) or 0.0)
+        time_remaining = float(rounds.get('time_remaining', 0.0) or 0.0)
+
+        if phase == 'intermission':
+            seconds = intermission_remaining
+        elif phase == 'secured':
+            seconds = hold_remaining if hold_remaining > 0.0 else time_remaining
+        else:
+            seconds = time_remaining
+
+        show_timer = seconds > 0.0 and phase != 'complete'
+        if show_timer:
+            timer_text = self._format_round_timer(seconds)
+            warn = phase in {'neutral', 'secured'} and seconds <= 10.0
+            color = self._round_timer_warn_color if warn else self._round_timer_base_color
+            self.round_timer_text.setTextColor(*color)
+            self.round_timer_text.setText(timer_text)
+        else:
+            self.round_timer_text.setText("")
+            self.round_timer_text.setTextColor(*self._round_timer_base_color)
+
+        if phase == 'complete':
+            phase_text = 'Match Complete'
+        elif phase == 'intermission':
+            next_round = (round_no or 0) + 1
+            phase_text = f"Round {next_round} starting" if show_timer else ''
+        elif phase == 'neutral':
+            phase_text = f"Round {round_no}" if round_no else 'Round'
+        elif phase == 'secured':
+            defender = self._coerce_team_value(rounds.get('defender'))
+            if defender in (TEAM_RED, TEAM_BLUE):
+                label = 'RED' if defender == TEAM_RED else 'BLUE'
+                phase_text = f"{label} defending"
+            else:
+                phase_text = 'Flag secured'
+        else:
+            phase_text = phase.replace('_', ' ').title() if phase else ''
+
+        self.round_phase_text.setText(phase_text)
+
     def _apply_recoil(self):
         # Accumulate recoil into aim offsets (do not move the camera)
         # Apply a fixed vertical kick per shot. No yaw jitter by default.
@@ -2914,6 +3021,7 @@ class GameApp(ShowBase):
         if latest:
             # map pid -> team for coloring names
             pid_team = {p.get("pid"): p.get("team") for p in latest.get("players", [])}
+
             feed = latest.get("killfeed", [])
             for ev in feed:
                 key = (int(float(ev.get("t", 0.0)) * 1000), ev.get("attacker"), ev.get("victim"))
@@ -2949,10 +3057,49 @@ class GameApp(ShowBase):
                     parts = [(name, team), " dropped the flag"]
                 elif evt == 'capture':
                     parts = [(name, team), " captured the flag!"]
+                elif evt == 'flag_secured':
+                    team_id = self._coerce_team_value(ev.get('team'))
+                    if team_id in (TEAM_RED, TEAM_BLUE):
+                        label = 'RED' if team_id == TEAM_RED else 'BLUE'
+                        parts = ["Team ", (label, team_id), " secured the flag"]
+                    else:
+                        parts = ["Flag secured"]
+                elif evt == 'round_start':
+                    round_no = ev.get('round')
+                    try:
+                        round_no = int(round_no)
+                    except Exception:
+                        round_no = None
+                    if round_no and round_no > 0:
+                        parts = [f"Round {round_no} started"]
+                    else:
+                        parts = ["Round started"]
+                elif evt == 'round_win':
+                    team_id = self._coerce_team_value(ev.get('team'))
+                    if team_id in (TEAM_RED, TEAM_BLUE):
+                        label = 'RED' if team_id == TEAM_RED else 'BLUE'
+                        parts = [(label, team_id), " won the round"]
+                    else:
+                        parts = ["Round won"]
+                    reason = ev.get('reason')
+                    if reason:
+                        parts.append(f" ({reason})")
+                elif evt == 'round_draw':
+                    round_no = ev.get('round')
+                    try:
+                        round_no = int(round_no)
+                    except Exception:
+                        round_no = None
+                    if round_no and round_no > 0:
+                        parts = [f"Round {round_no} ended in a draw"]
+                    else:
+                        parts = ["Round ended in a draw"]
                 else:
                     parts = [(name, team), f" {evt}"]
                 norm = [(p, None) if isinstance(p, str) else p for p in parts]
                 self.msg_feed.add_parts(norm)
+
+        self._update_round_hud(latest)
 
         # expire old killfeed entries (no fade, simple TTL)
         nowt = time.time()

--- a/configs/defaults.json
+++ b/configs/defaults.json
@@ -9,6 +9,14 @@
     "respawn_seconds": 1,
     "flag_return_seconds": 10,
     "friendly_fire": false,
+    "rounds": {
+      "enabled": false,
+      "to_win": 3,
+      "hold_seconds": 35.0,
+      "pickup_seconds": 5.0,
+      "setup_seconds": 5.0,
+      "round_seconds": 120.0
+    },
     "bot": {
       "fill": true,
       "per_team_target": 5,

--- a/game/ecs/replication.py
+++ b/game/ecs/replication.py
@@ -37,11 +37,16 @@ class SnapshotBuilder:
         match_over: bool,
         winner: Optional[int],
         corpse_angles: Dict[int, Tuple[float, float, float]],
+        rounds: Optional[Dict[str, Any]] = None,
         bot_debug: Optional[Dict[int, Dict[str, Any]]] = None,
+        teams_state: Optional[Dict[int, Dict[str, Any]]] = None,
+        hud: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         players = self._collect_players(now_t, corpse_angles)
         flags = self._collect_flags()
-        teams = {team_id: {"captures": captures} for team_id, captures in team_captures.items()}
+        teams = teams_state if teams_state is not None else {
+            team_id: {"captures": captures} for team_id, captures in team_captures.items()
+        }
 
         snapshot = {
             "type": "state",
@@ -57,6 +62,10 @@ class SnapshotBuilder:
             "killfeed": list(killfeed),
             "messages": list(messages),
         }
+        if rounds is not None:
+            snapshot["rounds"] = rounds
+        if hud is not None:
+            snapshot["hud"] = hud
         if bot_debug:
             snapshot["bot_debug"] = {
                 str(pid): data for pid, data in bot_debug.items()

--- a/game/modes/__init__.py
+++ b/game/modes/__init__.py
@@ -1,0 +1,11 @@
+"""Game mode implementations."""
+from .base import GameMode, ModeSystems
+from .neutral_flag import NeutralFlagGameMode
+from .rounds import RoundNeutralFlagGameMode
+
+__all__ = [
+    "GameMode",
+    "ModeSystems",
+    "NeutralFlagGameMode",
+    "RoundNeutralFlagGameMode",
+]

--- a/game/modes/base.py
+++ b/game/modes/base.py
@@ -1,0 +1,330 @@
+"""Game mode base classes and helpers."""
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Tuple, TYPE_CHECKING
+
+from panda3d.core import Vec3
+
+from game.constants import TEAM_BLUE, TEAM_RED
+from game.ecs import (
+    CharacterBody,
+    FlagCarrier,
+    Health,
+    MovementState,
+    Physics,
+    PlayerInfo,
+    PlayerInput as ECSPlayerInput,
+    PlayerStats,
+    Position,
+    Weapon,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+    from server import LaserTagServer
+    from game.ecs import CombatSystem, CollisionSystem, MovementSystem
+    from game.ecs.views import PlayerView, FlagView
+
+
+@dataclass
+class ModeSystems:
+    """Container bundling the ECS systems a mode contributes."""
+
+    pre_physics: List[Any]
+    post_physics: List[Any]
+    movement: Optional["MovementSystem"] = None
+    combat: Optional["CombatSystem"] = None
+    collision: Optional["CollisionSystem"] = None
+
+
+class GameMode:
+    """Abstract game mode facade used by the authoritative server."""
+
+    def __init__(self, server: "LaserTagServer", cfg: Dict[str, Any]) -> None:
+        self.server = server
+        self.cfg = cfg
+
+    # --- Lifecycle --------------------------------------------------
+    def setup(self) -> None:
+        """Called once the server has finished constructing core state."""
+
+    def build_systems(self) -> ModeSystems:
+        """Create the ECS systems this mode requires."""
+
+        from game.ecs import CombatSystem, CollisionSystem, MovementSystem
+
+        gameplay_cfg = self.server.cfg.get("gameplay", {})
+        server_cfg = self.server.cfg.get("server", {})
+
+        movement = MovementSystem(self.server.ecs, gameplay_cfg)
+        combat = CombatSystem(
+            self.server.ecs,
+            gameplay_cfg,
+            server_cfg,
+            self.server.world,
+            voxel_query=self.server._voxel_query,
+            now_fn=time.time,
+        )
+        collision = CollisionSystem(self.server.ecs, gameplay_cfg)
+        return ModeSystems(
+            pre_physics=[movement, combat],
+            post_physics=[movement, collision],
+            movement=movement,
+            combat=combat,
+            collision=collision,
+        )
+
+    # --- Team & HUD data -------------------------------------------
+    def teams(self) -> Iterable[int]:
+        """Return the team identifiers the mode supports."""
+
+        return (TEAM_RED, TEAM_BLUE)
+
+    def team_snapshot(self) -> Dict[int, Dict[str, Any]]:
+        """Return scoreboard payload for each team."""
+
+        captures = self.server.team_captures
+        return {int(team): {"captures": captures.get(team, 0)} for team in self.teams()}
+
+    def hud_snapshot(self, now_t: float) -> Optional[Dict[str, Any]]:
+        """Optional mode-specific HUD payload for clients."""
+
+        return None
+
+    # --- Player lifecycle ------------------------------------------
+    def select_team(self) -> int:
+        """Choose the team for a newly joining player."""
+
+        red_ct = sum(1 for p in self.server.player_views.values() if p.team == TEAM_RED)
+        blue_ct = sum(1 for p in self.server.player_views.values() if p.team == TEAM_BLUE)
+        return TEAM_RED if red_ct <= blue_ct else TEAM_BLUE
+
+    def spawn_location(self, team: int) -> Tuple[float, float, float, float]:
+        """Return (x, y, z, yaw_rad) for the given team."""
+
+        base = self.server.mapdata.red_base if team == TEAM_RED else self.server.mapdata.blue_base
+        x, y, z = self.server._find_safe_spawn_near((base[0], base[1]))
+        yaw_rad = 0.0 if team == TEAM_RED else math.pi
+        return x, y, z, yaw_rad
+
+    def create_player_info(self, pid: int, name: str, team: int, is_bot: bool) -> PlayerInfo:
+        return PlayerInfo(pid=pid, name=name, team=team, is_bot=is_bot)
+
+    def create_weapon(self, team: int, is_bot: bool) -> Weapon:
+        gameplay = self.server.cfg.get("gameplay", {})
+        shots_per_mag = int(gameplay.get("shots_per_mag", 20))
+        return Weapon(
+            shots_remaining=shots_per_mag,
+            shots_per_mag=shots_per_mag,
+            reload_end=0.0,
+            last_fire_time=0.0,
+            cooldown=0.0,
+            spread_deg=float(gameplay.get("base_spread_deg", 1.0)),
+            recoil_accum=0.0,
+        )
+
+    def create_health(self, team: int, is_bot: bool) -> Health:
+        return Health(hp=1, max_hp=1, alive=True, respawn_at=0.0)
+
+    def create_player_stats(self) -> PlayerStats:
+        return PlayerStats()
+
+    def create_flag_carrier(self) -> FlagCarrier:
+        return FlagCarrier(flag_team=None)
+
+    def add_player(self, name: str, is_bot: bool = False) -> int:
+        """Create a new player controlled by a client or bot."""
+
+        team = self.select_team()
+        pid = self.server.next_pid
+        self.server.next_pid += 1
+
+        x, y, z, yaw_rad = self.spawn_location(team)
+
+        entity = self.server.ecs.create_entity()
+        self.server.pid_to_entity[pid] = entity
+        self.server.entity_to_pid[entity] = pid
+
+        position = Position(x=x, y=y, z=z, yaw=yaw_rad, pitch=0.0)
+        physics = Physics(vx=0.0, vy=0.0, vz=0.0, on_ground=True)
+        movement = MovementState()
+        inputs = ECSPlayerInput(yaw=math.degrees(yaw_rad), pitch=0.0)
+        info = self.create_player_info(pid, name, team, is_bot)
+        weapon = self.create_weapon(team, is_bot)
+        health = self.create_health(team, is_bot)
+        stats = self.create_player_stats()
+        carrier = self.create_flag_carrier()
+
+        self.server.ecs.add_component(entity, position)
+        self.server.ecs.add_component(entity, physics)
+        self.server.ecs.add_component(entity, movement)
+        self.server.ecs.add_component(entity, inputs)
+        self.server.ecs.add_component(entity, info)
+        self.server.ecs.add_component(entity, weapon)
+        self.server.ecs.add_component(entity, health)
+        self.server.ecs.add_component(entity, stats)
+        self.server.ecs.add_component(entity, carrier)
+
+        from game.ecs.views import PlayerView
+
+        player_view = PlayerView(
+            pid=pid,
+            info=info,
+            position=position,
+            physics=physics,
+            movement=movement,
+            weapon=weapon,
+            health=health,
+            stats=stats,
+            flag_carrier=carrier,
+        )
+        self.server.player_views[pid] = player_view
+
+        self.server._create_character(entity, pid, (x, y, z), yaw_rad)
+        self.server._last_safe_pos[pid] = (x, y, z)
+
+        if is_bot:
+            brain = self.create_bot_brain(player_view)
+            if brain is not None:
+                self.server.bot_brains[pid] = brain
+
+        print(f"[join] pid={pid} name={name} team={'RED' if team==TEAM_RED else 'BLUE'}")
+        return pid
+
+    def create_bot_brain(self, player: "PlayerView"):
+        """Return an optional bot brain for ``player``."""
+
+        if not player.is_bot:
+            return None
+
+        from game.bot_ai import AStarBotBrain
+
+        team = player.team
+        base_pos = self.server.mapdata.red_base if team == TEAM_RED else self.server.mapdata.blue_base
+        enemy_base = self.server.mapdata.blue_base if team == TEAM_RED else self.server.mapdata.red_base
+
+        bot_cfg = self.server.cfg.get("server", {}).get("bot", {})
+        target_players = bool(bot_cfg.get("target_players", True))
+        turn_cfg = bot_cfg.get("turn_rates", {})
+        idle_turn = float(turn_cfg.get("idle", 240.0))
+        engaged_turn = float(turn_cfg.get("engaged", 420.0))
+        engagement_range = float(bot_cfg.get("engagement_range_m", 40.0))
+        target_acquire_range = float(bot_cfg.get("target_acquire_range_m", max(engagement_range, 45.0)))
+        if target_acquire_range < engagement_range:
+            target_acquire_range = engagement_range
+
+        return AStarBotBrain(
+            team,
+            base_pos,
+            enemy_base,
+            target_players=target_players,
+            nav_graph=self.server.nav_graph,
+            idle_turn_rate_deg=idle_turn,
+            engaged_turn_rate_deg=engaged_turn,
+            engagement_range_m=engagement_range,
+            target_acquire_range_m=target_acquire_range,
+        )
+
+    def spawn_weapon_state(self, team: int, is_bot: bool) -> Dict[str, float]:
+        """Return weapon parameters that should be applied on spawn."""
+
+        shots_per_mag = int(self.server.cfg.get("gameplay", {}).get("shots_per_mag", 20))
+        return {
+            "shots_per_mag": shots_per_mag,
+            "shots_remaining": shots_per_mag,
+            "reload_end": 0.0,
+            "recoil_accum": 0.0,
+        }
+
+    def respawn_player(self, pid: int) -> None:
+        """Reset state and move the player to a spawn location."""
+
+        player = self.server.gs.players.get(pid)
+        if not player:
+            return
+
+        self.server._remove_corpse(pid)
+
+        x, y, z, yaw_rad = self.spawn_location(player.team)
+        player.x, player.y, player.z = x, y, z
+        player.yaw_rad = yaw_rad
+        player.pitch_rad = 0.0
+        player.vx = player.vy = player.vz = 0.0
+        player.on_ground = True
+        player.crouching = False
+        player.walking = False
+        player.carrying_flag = None
+        player.alive = True
+        player.respawn_at = 0.0
+
+        weapon_state = self.spawn_weapon_state(player.team, player.is_bot)
+        player.shots_per_mag = int(weapon_state["shots_per_mag"])
+        player.shots_remaining = int(weapon_state["shots_remaining"])
+        player.reload_end = float(weapon_state["reload_end"])
+        player.recoil_accum = float(weapon_state["recoil_accum"])
+
+        self.server._last_safe_pos[pid] = (x, y, z)
+
+        entity = self.server.pid_to_entity.get(pid)
+        if entity is not None:
+            inputs = self.server.ecs.get_component(entity, ECSPlayerInput)
+            if inputs:
+                inputs.yaw = math.degrees(yaw_rad)
+                inputs.pitch = 0.0
+                inputs.mx = 0.0
+                inputs.mz = 0.0
+                inputs.fire = False
+                inputs.jump = False
+                inputs.walk = False
+                inputs.crouch = False
+
+            body = self.server.ecs.get_component(entity, CharacterBody)
+            if body is None or getattr(body, "nodepath", None) is None:
+                self.server._create_character(entity, pid, (x, y, z), yaw_rad)
+            else:
+                try:
+                    body.nodepath.setPos(x, y, z)
+                    body.controller.setLinearMovement(Vec3(0, 0, 0), False)
+                except Exception:
+                    pass
+
+            health = self.server.ecs.get_component(entity, Health)
+            if health:
+                max_hp = getattr(health, "max_hp", 1) or 1
+                health.hp = max(1, int(max_hp))
+                health.alive = True
+                health.respawn_at = 0.0
+
+    # --- Per-frame hooks ---------------------------------------------
+    def pre_tick(self, now_t: float) -> None:
+        """Called at the start of each simulation tick."""
+
+    def after_flag_interactions(self, dt: float) -> None:
+        """Called after flag touch checks each tick."""
+
+    # --- Core behaviour ----------------------------------------------
+    def handle_flag_touch(self, player: "PlayerView", team_flag: int, flag: "FlagView") -> bool:
+        """Return True if the mode consumed the interaction with ``flag``."""
+
+        return False
+
+    def respawns_locked(self) -> bool:
+        """Return True if players should not respawn this frame."""
+
+        return False
+
+    def check_objectives(self) -> None:
+        """Evaluate win conditions and objective progress for the mode."""
+
+    def snapshot(self, now_t: float) -> Optional[Dict[str, Any]]:
+        """Return additional snapshot payload for clients."""
+
+        return None
+
+    # --- Extension points used by derived modes ----------------------
+    def on_neutral_flag_delivered(self, carrier: "PlayerView", flag: "FlagView") -> bool:
+        """Hook when a neutral flag carrier reaches their home base."""
+
+        return False

--- a/game/modes/neutral_flag.py
+++ b/game/modes/neutral_flag.py
@@ -1,0 +1,105 @@
+"""Neutral flag capture-the-flag game mode."""
+from __future__ import annotations
+
+import math
+import time
+from typing import Dict, Any, TYPE_CHECKING
+
+from game.constants import TEAM_RED, TEAM_BLUE, TEAM_NEUTRAL, BASE_CAPTURE_RADIUS
+
+from .base import GameMode
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from game.ecs.views import PlayerView, FlagView
+
+
+class NeutralFlagGameMode(GameMode):
+    """Classic neutral-flag capture mode used by default."""
+
+    def __init__(self, server, cfg: Dict[str, Any]) -> None:
+        super().__init__(server, cfg)
+        server_cfg = server.cfg.get("server", {})
+        self.to_win = int(server_cfg.get("captures_to_win", 3))
+
+    # ------------------------------------------------------------------
+    def check_objectives(self) -> None:
+        if self.server.match_over:
+            return
+        self._check_match_end()
+        if self.server.match_over:
+            return
+        self._check_flag_captures()
+
+    # ------------------------------------------------------------------
+    def _check_match_end(self) -> None:
+        for team in (TEAM_RED, TEAM_BLUE):
+            if self.server.gs.teams[team].captures >= self.to_win:
+                self.server.match_over = True
+                self.server.winner = team
+                return
+
+    def _check_flag_captures(self) -> None:
+        flags = self.server.gs.flags
+        players = list(self.server.gs.players.items())
+        for pid, player in players:
+            if not player.alive:
+                continue
+            if TEAM_NEUTRAL in flags and len(flags) == 1:
+                flag = next(iter(flags.values()))
+                if flag.carried_by != pid:
+                    continue
+                if self.on_neutral_flag_delivered(player, flag):
+                    continue
+                base = self.server.mapdata.red_base if player.team == TEAM_RED else self.server.mapdata.blue_base
+                if math.hypot(player.x - base[0], player.y - base[1]) <= BASE_CAPTURE_RADIUS:
+                    self._award_neutral_capture(player, flag)
+                continue
+
+            enemy_team = TEAM_BLUE if player.team == TEAM_RED else TEAM_RED
+            flag = flags.get(enemy_team)
+            if not flag or flag.carried_by != pid:
+                continue
+            base = self.server.mapdata.red_base if player.team == TEAM_RED else self.server.mapdata.blue_base
+            if math.hypot(player.x - base[0], player.y - base[1]) <= BASE_CAPTURE_RADIUS:
+                self._award_team_capture(player, flag)
+
+    def _award_neutral_capture(self, player: "PlayerView", flag: "FlagView") -> None:
+        flag.carried_by = None
+        flag.at_base = True
+        fx, fy, fz = self.server._flag_home_pos(flag)
+        flag.x, flag.y, flag.z = fx, fy, fz
+        flag.dropped_at_time = 0.0
+        player.captures += 1
+        player.carrying_flag = None
+        self.server.gs.teams[player.team].captures += 1
+        score = self.server.gs.teams[player.team].captures
+        print(f"[score] Team {'RED' if player.team==TEAM_RED else 'BLUE'} captured! -> {score}")
+        self._log_message("capture", actor=player)
+        self._check_match_end()
+
+    def _award_team_capture(self, player: "PlayerView", flag: "FlagView") -> None:
+        flag.carried_by = None
+        flag.at_base = True
+        fx, fy, fz = self.server._flag_home_pos(flag)
+        flag.x, flag.y, flag.z = fx, fy, fz
+        flag.dropped_at_time = 0.0
+        player.captures += 1
+        player.carrying_flag = None
+        self.server.gs.teams[player.team].captures += 1
+        score = self.server.gs.teams[player.team].captures
+        print(f"[score] Team {'RED' if player.team==TEAM_RED else 'BLUE'} captured! -> {score}")
+        self._log_message("capture", actor=player)
+        self._check_match_end()
+
+    def _log_message(self, event: str, *, actor: "PlayerView") -> None:
+        try:
+            self.server.messagefeed.append(
+                {
+                    "t": time.time(),
+                    "event": event,
+                    "actor": actor.pid,
+                    "actor_name": actor.name,
+                }
+            )
+        except Exception:
+            pass

--- a/game/modes/rounds.py
+++ b/game/modes/rounds.py
@@ -1,0 +1,305 @@
+"""Round-based neutral flag mode."""
+from __future__ import annotations
+
+import math
+import time
+from typing import Dict, Any, Optional, Set, TYPE_CHECKING
+
+from game.constants import TEAM_RED, TEAM_BLUE, TEAM_NEUTRAL, FLAG_PICKUP_RADIUS
+
+from .neutral_flag import NeutralFlagGameMode
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from game.ecs.views import PlayerView, FlagView
+
+
+class RoundNeutralFlagGameMode(NeutralFlagGameMode):
+    """Counter-Strike inspired neutral flag rounds."""
+
+    def __init__(self, server, cfg: Dict[str, Any]) -> None:
+        super().__init__(server, cfg)
+        rounds_cfg = dict(server.cfg.get("server", {}).get("rounds", {}))
+        captures_goal = int(server.cfg.get("server", {}).get("captures_to_win", 3))
+        self.to_win = int(rounds_cfg.get("to_win", captures_goal))
+        self.hold_seconds = float(rounds_cfg.get("hold_seconds", 35.0))
+        self.pickup_seconds = float(rounds_cfg.get("pickup_seconds", 5.0))
+        self.setup_seconds = float(rounds_cfg.get("setup_seconds", 5.0))
+        self.round_seconds = float(rounds_cfg.get("round_seconds", 120.0))
+
+        self.round_index = 0
+        self.round_phase: str = "intermission"
+        self.round_defender: Optional[int] = None
+        self.round_attacker: Optional[int] = None
+        self.round_hold_until: float = 0.0
+        self.round_secure_started: float = 0.0
+        self.round_pickup_progress: float = 0.0
+        self.round_deadline_at: float = 0.0
+        self._pickup_contenders: Set[int] = set()
+        self._next_start_at: float = 0.0
+
+    # ------------------------------------------------------------------
+    def setup(self) -> None:
+        # Round wins determine the match target.
+        self.server.cfg.setdefault("server", {})["captures_to_win"] = self.to_win
+        self._schedule_intermission(self.setup_seconds)
+
+    # ------------------------------------------------------------------
+    def pre_tick(self, now_t: float) -> None:
+        if self.server.match_over:
+            return
+        if self.round_phase == "intermission" and now_t >= self._next_start_at:
+            self._begin_round()
+        self._pickup_contenders.clear()
+
+    def after_flag_interactions(self, dt: float) -> None:
+        if self.server.match_over or self.round_phase != "secured":
+            return
+        if not self._pickup_contenders:
+            self.round_pickup_progress = 0.0
+            return
+        attackers = [
+            pid
+            for pid in self._pickup_contenders
+            if pid in self.server.gs.players and self.server.gs.players[pid].alive
+        ]
+        if not attackers:
+            self.round_pickup_progress = 0.0
+            return
+        base_time = max(0.1, self.pickup_seconds)
+        self.round_pickup_progress += dt * len(attackers) / base_time
+        if self.round_pickup_progress >= 1.0:
+            self._award_round(self.round_attacker, "recovered")
+        else:
+            self.round_pickup_progress = min(1.0, self.round_pickup_progress)
+
+    def handle_flag_touch(self, player: "PlayerView", team_flag: int, flag: "FlagView") -> bool:
+        if (
+            team_flag == TEAM_NEUTRAL
+            and self.round_phase == "secured"
+            and self.round_attacker == player.team
+            and player.alive
+        ):
+            distance = math.hypot(player.x - flag.x, player.y - flag.y)
+            if distance <= FLAG_PICKUP_RADIUS:
+                self._pickup_contenders.add(player.pid)
+            return True
+        return False
+
+    def respawns_locked(self) -> bool:
+        return self.round_phase in {"neutral", "secured", "intermission"}
+
+    def check_objectives(self) -> None:
+        if self.server.match_over:
+            return
+        self._check_flag_captures()
+        if (
+            self.round_phase == "secured"
+            and self.round_hold_until > 0.0
+            and time.time() >= self.round_hold_until
+        ):
+            self._award_round(self.round_defender, "hold")
+        self._check_elimination()
+        self._check_round_timeout()
+        self._check_match_end()
+
+    def on_neutral_flag_delivered(self, carrier: "PlayerView", flag: "FlagView") -> bool:
+        if self.round_phase != "neutral":
+            return False
+        self._flag_secured(carrier.team, flag, carrier)
+        return True
+
+    def snapshot(self, now_t: float) -> Optional[Dict[str, Any]]:
+        hold_remaining = 0.0
+        pickup = 0.0
+        round_remaining = 0.0
+        intermission_remaining = 0.0
+        if self.round_phase in {"neutral", "secured"} and self.round_deadline_at > 0.0:
+            round_remaining = max(0.0, self.round_deadline_at - now_t)
+        if self.round_phase == "intermission" and self._next_start_at > 0.0:
+            intermission_remaining = max(0.0, self._next_start_at - now_t)
+        if self.round_phase == "secured":
+            if self.round_hold_until > 0.0:
+                hold_remaining = max(0.0, self.round_hold_until - now_t)
+            pickup = max(0.0, min(1.0, self.round_pickup_progress))
+        wins = {
+            TEAM_RED: int(self.server.team_captures.get(TEAM_RED, 0)),
+            TEAM_BLUE: int(self.server.team_captures.get(TEAM_BLUE, 0)),
+        }
+        return {
+            "enabled": True,
+            "current": int(self.round_index),
+            "phase": self.round_phase,
+            "defender": self.round_defender,
+            "attacker": self.round_attacker,
+            "hold_remaining": hold_remaining,
+            "pickup_progress": pickup,
+            "round_time_remaining": round_remaining,
+            "intermission_remaining": intermission_remaining,
+            "deadline": self.round_deadline_at if self.round_deadline_at > 0.0 else None,
+            "round_seconds": float(self.round_seconds),
+            "to_win": int(self.to_win),
+            "wins": wins,
+        }
+
+    def hud_snapshot(self, now_t: float) -> Optional[Dict[str, Any]]:
+        hud_time = 0.0
+        if self.server.match_over and self.round_phase == "complete":
+            hud_time = 0.0
+        elif self.round_phase in {"neutral", "secured"} and self.round_deadline_at > 0.0:
+            hud_time = max(0.0, self.round_deadline_at - now_t)
+        intermission = 0.0
+        if self.round_phase == "intermission" and self._next_start_at > 0.0:
+            intermission = max(0.0, self._next_start_at - now_t)
+        hold_remaining = 0.0
+        if self.round_phase == "secured" and self.round_hold_until > 0.0:
+            hold_remaining = max(0.0, self.round_hold_until - now_t)
+        return {
+            "rounds": {
+                "enabled": True,
+                "round": int(self.round_index),
+                "phase": self.round_phase,
+                "time_remaining": hud_time,
+                "intermission_remaining": intermission,
+                "hold_remaining": hold_remaining,
+                "defender": self.round_defender,
+                "attacker": self.round_attacker,
+                "to_win": int(self.to_win),
+                "wins": {
+                    TEAM_RED: int(self.server.team_captures.get(TEAM_RED, 0)),
+                    TEAM_BLUE: int(self.server.team_captures.get(TEAM_BLUE, 0)),
+                },
+            }
+        }
+
+    def _schedule_intermission(self, delay: float) -> None:
+        self.round_phase = "intermission"
+        self.round_defender = None
+        self.round_attacker = None
+        self.round_hold_until = 0.0
+        self.round_secure_started = 0.0
+        self.round_pickup_progress = 0.0
+        self.round_deadline_at = 0.0
+        self._pickup_contenders.clear()
+        self._next_start_at = time.time() + max(0.0, delay)
+        self._reset_flag_position()
+
+    def _begin_round(self) -> None:
+        if self.server.match_over:
+            return
+        self.round_index += 1
+        self.round_phase = "neutral"
+        self.round_defender = None
+        self.round_attacker = None
+        self.round_hold_until = 0.0
+        now_t = time.time()
+        self.round_secure_started = now_t
+        self.round_pickup_progress = 0.0
+        self.round_deadline_at = (now_t + max(0.0, self.round_seconds)) if self.round_seconds > 0.0 else 0.0
+        self._pickup_contenders.clear()
+        self._reset_flag_position()
+        for pid in list(self.server.gs.players.keys()):
+            self.server.respawn_player(pid)
+        self._next_start_at = 0.0
+        print(f"[round] starting round {self.round_index}")
+        self._log_event("round_start", {"round": self.round_index})
+
+    def _reset_flag_position(self) -> None:
+        flag = self.server.gs.flags.get(TEAM_NEUTRAL)
+        if flag is None:
+            return
+        fx, fy, fz = self.server._flag_home_pos(flag)
+        flag.carried_by = None
+        flag.at_base = True
+        flag.x, flag.y, flag.z = fx, fy, fz
+        flag.dropped_at_time = 0.0
+        for player in self.server.gs.players.values():
+            if getattr(player, "carrying_flag", None) == TEAM_NEUTRAL:
+                player.carrying_flag = None
+
+    def _flag_secured(self, team: int, flag: "FlagView", carrier: "PlayerView") -> None:
+        self.round_defender = team
+        self.round_attacker = TEAM_BLUE if team == TEAM_RED else TEAM_RED
+        self.round_phase = "secured"
+        now_t = time.time()
+        self.round_secure_started = now_t
+        hold_until = now_t + max(0.0, self.hold_seconds)
+        self.round_hold_until = hold_until
+        self.round_deadline_at = hold_until
+        self.round_pickup_progress = 0.0
+        self._pickup_contenders.clear()
+        pedestal = (
+            self.server.mapdata.red_flag_stand
+            if team == TEAM_RED
+            else self.server.mapdata.blue_flag_stand
+        )
+        flag.carried_by = None
+        flag.at_base = True
+        flag.x, flag.y, flag.z = pedestal
+        flag.dropped_at_time = 0.0
+        carrier.carrying_flag = None
+        print(f"[round] Team {'RED' if team==TEAM_RED else 'BLUE'} secured the flag")
+        self._log_event("flag_secured", {"team": team})
+
+    def _check_elimination(self) -> None:
+        if self.round_phase not in {"neutral", "secured"}:
+            return
+        red_alive = any(p.alive for p in self.server.gs.players.values() if p.team == TEAM_RED)
+        blue_alive = any(p.alive for p in self.server.gs.players.values() if p.team == TEAM_BLUE)
+        if red_alive and blue_alive:
+            return
+        if red_alive and not blue_alive:
+            self._award_round(TEAM_RED, "elimination")
+        elif blue_alive and not red_alive:
+            self._award_round(TEAM_BLUE, "elimination")
+
+    def _check_round_timeout(self) -> None:
+        if self.round_phase not in {"neutral", "secured"}:
+            return
+        if self.round_deadline_at <= 0.0:
+            return
+        if time.time() < self.round_deadline_at:
+            return
+        self._handle_round_draw()
+
+    def _handle_round_draw(self) -> None:
+        if self.server.match_over or self.round_phase not in {"neutral", "secured"}:
+            return
+        print(f"[round] Round {self.round_index} expired -> draw")
+        self._log_event("round_draw", {"round": self.round_index})
+        self.round_hold_until = 0.0
+        self.round_pickup_progress = 0.0
+        self.round_deadline_at = 0.0
+        self._pickup_contenders.clear()
+        self._schedule_intermission(self.setup_seconds)
+
+    def _award_round(self, team: Optional[int], reason: str) -> None:
+        if team is None or self.server.match_over or self.round_phase == "complete":
+            return
+        current = int(self.server.team_captures.get(team, 0))
+        self.server.team_captures[team] = current + 1
+        self.round_hold_until = 0.0
+        self.round_pickup_progress = 0.0
+        self.round_deadline_at = 0.0
+        self._pickup_contenders.clear()
+        self._log_event("round_win", {"team": team, "reason": reason})
+        print("[round] Team {} wins round {} ({}) -> {}".format(
+            "RED" if team == TEAM_RED else "BLUE",
+            self.round_index,
+            reason,
+            self.server.team_captures[team],
+        ))
+        if self.server.team_captures[team] >= self.to_win:
+            self.server.match_over = True
+            self.server.winner = team
+            self.round_phase = "complete"
+            self._next_start_at = float("inf")
+            self._reset_flag_position()
+        else:
+            self._schedule_intermission(self.setup_seconds)
+
+    def _log_event(self, event: str, payload: Dict[str, Any]) -> None:
+        data = {"t": time.time(), "event": event, **payload}
+        try:
+            self.server.messagefeed.append(data)
+        except Exception:
+            pass

--- a/scoreboard.py
+++ b/scoreboard.py
@@ -35,6 +35,9 @@ class Scoreboard:
             return
         players = state.get("players", [])
         teams = state.get("teams", {})
+        rounds_state = state.get("rounds") or {}
+        rounds_enabled = bool(rounds_state.get("enabled"))
+        round_wins = rounds_state.get("wins", {})
         by_team = {TEAM_RED: [], TEAM_BLUE: []}
         for p in players:
             by_team.setdefault(p.get("team"), []).append(p)
@@ -46,8 +49,9 @@ class Scoreboard:
         header = OnscreenText(
             "Name", pos=(base_x, y), align=TextNode.ALeft, fg=(1, 1, 1, 1), scale=0.045
         )
+        stat_label = "Rnd" if rounds_enabled else "Cap"
         header_stats = OnscreenText(
-            "Ping  Tags  Outs  Cap  Def",
+            f"Ping  Tags  Outs  {stat_label}  Def",
             pos=(base_x + 0.6, y),
             align=TextNode.ALeft,
             fg=(1, 1, 1, 1),
@@ -59,7 +63,10 @@ class Scoreboard:
             tname = "RED" if team == TEAM_RED else "BLUE"
             # some JSON decoders may coerce int keys to strings; handle both
             tkey = team if team in teams else str(team)
+            round_key = team if team in round_wins else str(team)
             points = teams.get(tkey, {}).get("captures", 0)
+            if rounds_enabled:
+                points = round_wins.get(round_key, points)
             team_line = OnscreenText(
                 f"{tname} - {points}",
                 pos=(base_x, y),

--- a/server.py
+++ b/server.py
@@ -1,7 +1,7 @@
 # server.py — Authoritative server with Bullet physics (players, block-built world, obstacles),
 # Bullet ray tests for lasers, safe-spawn, auto-unstick, and shared solid collide-mask fix.
-import asyncio, json, math, time, random, argparse, signal
-from typing import Dict, Any, List, Tuple, Optional, Set
+import asyncio, json, math, time, random, argparse, signal, importlib
+from typing import Dict, Any, List, Tuple, Optional, Set, Type
 from bisect import bisect_right
 
 from common.net import read_json, send_json, lan_discovery_server
@@ -18,25 +18,20 @@ from game.ecs import (
     World as ECSWorld,
     CharacterBody,
     CollisionBody,
-    FlagCarrier,
     FlagState,
-    CombatSystem,
-    CollisionSystem,
     GrenadeRequest,
     Health,
     HitEvent,
     MovementState,
-    MovementSystem,
     Physics,
-    PlayerInfo,
     PlayerInput as ECSPlayerInput,
-    PlayerStats,
     Position,
     Projectile,
     Weapon,
 )
 from game.ecs.replication import SnapshotBuilder
 from game.ecs.views import GameStateView, PlayerView, FlagView, TeamView
+from game.modes import GameMode, NeutralFlagGameMode, RoundNeutralFlagGameMode
 
 # --- Panda3D / Bullet (headless) ---
 from panda3d.core import Vec3, Point3, NodePath, BitMask32, LPoint3
@@ -115,10 +110,11 @@ class LaserTagServer:
         # Legacy views backed by ECS components
         self.player_views: Dict[int, PlayerView] = {}
         self.flag_views: Dict[int, FlagView] = {}
-        self.team_captures: Dict[int, int] = {TEAM_RED: 0, TEAM_BLUE: 0}
+        server_cfg = self.cfg.setdefault("server", {})
+        self.game_mode: GameMode = self._create_game_mode(server_cfg)
+        self.team_captures: Dict[int, int] = {int(team): 0 for team in self.game_mode.teams()}
         self.team_views: Dict[int, TeamView] = {
-            TEAM_RED: TeamView(self.team_captures, TEAM_RED),
-            TEAM_BLUE: TeamView(self.team_captures, TEAM_BLUE),
+            int(team): TeamView(self.team_captures, int(team)) for team in self.game_mode.teams()
         }
         self.match_over: bool = False
         self.winner: Optional[int] = None
@@ -173,23 +169,43 @@ class LaserTagServer:
         self._stuck_since: Dict[int, float] = {}
         self._last_safe_pos: Dict[int, Tuple[float,float,float]] = {}
 
-        # ECS systems – movement/combat/collision
-        self.movement_system = MovementSystem(self.ecs, self.cfg["gameplay"])
-        self.combat_system = CombatSystem(
-            self.ecs,
-            self.cfg["gameplay"],
-            self.cfg["server"],
-            self.world,
-            voxel_query=self._voxel_query,
-            now_fn=now,
-        )
-        self.collision_system = CollisionSystem(self.ecs, self.cfg["gameplay"])
-        self._pre_physics_systems = [self.movement_system, self.combat_system]
-        self._post_physics_systems = [self.movement_system, self.collision_system]
+        systems = self.game_mode.build_systems()
+        self.movement_system = systems.movement
+        self.combat_system = systems.combat
+        self.collision_system = systems.collision
+        self._pre_physics_systems = [sys for sys in systems.pre_physics if sys is not None]
+        self._post_physics_systems = [sys for sys in systems.post_physics if sys is not None]
 
         self._build_static_world()
-        self.combat_system.voxel_query = self._voxel_query
+        if self.combat_system is not None:
+            self.combat_system.voxel_query = self._voxel_query
         self._init_flag_entities()
+        self.game_mode.setup()
+
+    def _create_game_mode(self, server_cfg: Dict[str, Any]) -> GameMode:
+        mode_spec = server_cfg.get("game_mode")
+        mode_cls: Type[GameMode]
+        if isinstance(mode_spec, str) and mode_spec.strip():
+            mode_cls = self._resolve_game_mode_class(mode_spec.strip())
+        elif bool(server_cfg.get("rounds", {}).get("enabled", False)):
+            mode_cls = RoundNeutralFlagGameMode
+        else:
+            mode_cls = NeutralFlagGameMode
+        return mode_cls(self, server_cfg)
+
+    def _resolve_game_mode_class(self, spec: str) -> Type[GameMode]:
+        if ":" in spec:
+            module_name, class_name = spec.split(":", 1)
+        else:
+            parts = spec.rsplit(".", 1)
+            if len(parts) != 2:
+                raise ValueError(f"Invalid game_mode specification '{spec}'")
+            module_name, class_name = parts
+        module = importlib.import_module(module_name)
+        cls = getattr(module, class_name)
+        if not isinstance(cls, type) or not issubclass(cls, GameMode):
+            raise TypeError(f"Game mode '{spec}' is not a GameMode subclass")
+        return cls
 
     def get_public_stats(self) -> Dict[str, Any]:
         """Return stats advertised to clients during discovery."""
@@ -200,6 +216,9 @@ class LaserTagServer:
         active_players = sum(1 for p in players if getattr(p, 'alive', False))
         max_players = int(self.cfg.get('server', {}).get('max_players', MAX_PLAYERS))
         captures_to_win = int(self.cfg.get('server', {}).get('captures_to_win', 0))
+        rounds_info = self.game_mode.snapshot(now())
+        if rounds_info:
+            captures_to_win = int(rounds_info.get('to_win', captures_to_win) or captures_to_win)
         stats: Dict[str, Any] = {
             'version': 1,
             'uptime': max(0.0, now() - self.start_time),
@@ -220,6 +239,13 @@ class LaserTagServer:
                 },
             },
         }
+        if rounds_info and rounds_info.get('enabled'):
+            stats['match']['rounds'] = {
+                'red': int(self.team_captures.get(TEAM_RED, 0)),
+                'blue': int(self.team_captures.get(TEAM_BLUE, 0)),
+                'to_win': int(rounds_info.get('to_win', captures_to_win)),
+                'phase': rounds_info.get('phase'),
+            }
         arena_size = self.cfg.get('gameplay', {}).get('arena_size_m')
         if isinstance(arena_size, (list, tuple)):
             stats['map'] = {'arena_size': [float(v) for v in arena_size[:2]]}
@@ -515,101 +541,13 @@ class LaserTagServer:
             self.ecs.add_component(entity, state)
             self.flag_views[team] = FlagView(entity=entity, state=state, position=pos)
 
+    # ---------- Rounds mode ----------
     # ---------- Players / bots ----------
     def assign_spawn(self, team: int) -> Tuple[float, float, float, float]:
-        base = self.mapdata.red_base if team == TEAM_RED else self.mapdata.blue_base
-        x, y, z = self._find_safe_spawn_near((base[0], base[1]))
-        yaw_rad = 0.0 if team == TEAM_RED else math.pi
-        return x, y, z, yaw_rad
+        return self.game_mode.spawn_location(team)
 
     def add_player(self, name: str, is_bot: bool = False) -> int:
-        red_ct = sum(1 for p in self.player_views.values() if p.team == TEAM_RED)
-        blue_ct = sum(1 for p in self.player_views.values() if p.team == TEAM_BLUE)
-        team = TEAM_RED if red_ct <= blue_ct else TEAM_BLUE
-
-        pid = self.next_pid
-        self.next_pid += 1
-
-        x, y, z, yaw_rad = self.assign_spawn(team)
-        shots_per_mag = int(self.cfg["gameplay"].get("shots_per_mag", 20))
-
-        entity = self.ecs.create_entity()
-        self.pid_to_entity[pid] = entity
-        self.entity_to_pid[entity] = pid
-
-        pos = Position(x=x, y=y, z=z, yaw=yaw_rad, pitch=0.0)
-        phys = Physics(vx=0.0, vy=0.0, vz=0.0, on_ground=True)
-        movement = MovementState()
-        inputs = ECSPlayerInput(yaw=math.degrees(yaw_rad), pitch=0.0)
-        info = PlayerInfo(pid=pid, name=name, team=team, is_bot=is_bot)
-        weapon = Weapon(
-            shots_remaining=shots_per_mag,
-            shots_per_mag=shots_per_mag,
-            reload_end=0.0,
-            last_fire_time=0.0,
-            cooldown=0.0,
-            spread_deg=float(self.cfg["gameplay"].get("base_spread_deg", 1.0)),
-            recoil_accum=0.0,
-        )
-        health = Health(hp=1, max_hp=1, alive=True, respawn_at=0.0)
-        stats = PlayerStats()
-        carrier = FlagCarrier(flag_team=None)
-
-        self.ecs.add_component(entity, pos)
-        self.ecs.add_component(entity, phys)
-        self.ecs.add_component(entity, movement)
-        self.ecs.add_component(entity, inputs)
-        self.ecs.add_component(entity, info)
-        self.ecs.add_component(entity, weapon)
-        self.ecs.add_component(entity, health)
-        self.ecs.add_component(entity, stats)
-        self.ecs.add_component(entity, carrier)
-
-        self.player_views[pid] = PlayerView(
-            pid=pid,
-            info=info,
-            position=pos,
-            physics=phys,
-            movement=movement,
-            weapon=weapon,
-            health=health,
-            stats=stats,
-            flag_carrier=carrier,
-        )
-
-        self._create_character(entity, pid, (x, y, z), yaw_rad)
-        self._last_safe_pos[pid] = (x, y, z)
-
-        if is_bot:
-            base_pos = self.mapdata.red_base if team == TEAM_RED else self.mapdata.blue_base
-            enemy_base = self.mapdata.blue_base if team == TEAM_RED else self.mapdata.red_base
-            from game.bot_ai import AStarBotBrain
-
-            bot_cfg = self.cfg.get("server", {}).get("bot", {})
-            target_players = bool(bot_cfg.get("target_players", True))
-            turn_cfg = bot_cfg.get("turn_rates", {})
-            idle_turn = float(turn_cfg.get("idle", 240.0))
-            engaged_turn = float(turn_cfg.get("engaged", 420.0))
-            engagement_range = float(bot_cfg.get("engagement_range_m", 40.0))
-            target_acquire_range = float(bot_cfg.get("target_acquire_range_m", max(engagement_range, 45.0)))
-            if target_acquire_range < engagement_range:
-                target_acquire_range = engagement_range
-
-            brain = AStarBotBrain(
-                team,
-                base_pos,
-                enemy_base,
-                target_players=target_players,
-                nav_graph=self.nav_graph,
-                idle_turn_rate_deg=idle_turn,
-                engaged_turn_rate_deg=engaged_turn,
-                engagement_range_m=engagement_range,
-                target_acquire_range_m=target_acquire_range,
-            )
-            self.bot_brains[pid] = brain
-
-        print(f"[join] pid={pid} name={name} team={'RED' if team==TEAM_RED else 'BLUE'}")
-        return pid
+        return self.game_mode.add_player(name, is_bot=is_bot)
 
     def remove_player(self, pid: int):
         if pid in self.clients:
@@ -637,77 +575,7 @@ class LaserTagServer:
             pass
 
     def respawn_player(self, pid: int):
-        p = self.gs.players.get(pid)
-        if not p:
-            return
-
-        # Remove any corpse body
-        self._remove_corpse(pid)
-
-        # Choose a safe spawn and reset state
-        x, y, z, yaw_rad = self.assign_spawn(p.team)
-        p.x, p.y, p.z = x, y, z
-        p.yaw_rad = yaw_rad
-        p.pitch_rad = 0.0
-        p.alive = True
-        p.respawn_at = 0.0
-        p.on_ground = True
-        p.crouching = False
-        p.walking = False
-        p.shots_remaining = int(self.cfg["gameplay"].get("shots_per_mag", 20))
-        p.reload_end = 0.0
-        p.recoil_accum = 0.0
-
-        entity = self.pid_to_entity.get(pid)
-        if entity is not None:
-            pos_comp = self.ecs.get_component(entity, Position)
-            if pos_comp:
-                pos_comp.x = x
-                pos_comp.y = y
-                pos_comp.z = z
-                pos_comp.yaw = yaw_rad
-                pos_comp.pitch = 0.0
-            phys_comp = self.ecs.get_component(entity, Physics)
-            if phys_comp:
-                phys_comp.vx = phys_comp.vy = phys_comp.vz = 0.0
-                phys_comp.on_ground = True
-            move_state = self.ecs.get_component(entity, MovementState)
-            if move_state:
-                move_state.walking = False
-                move_state.crouching = False
-            input_comp = self.ecs.get_component(entity, ECSPlayerInput)
-            if input_comp:
-                input_comp.yaw = math.degrees(yaw_rad)
-                input_comp.pitch = 0.0
-                input_comp.mx = 0.0
-                input_comp.mz = 0.0
-                input_comp.fire = False
-                input_comp.jump = False
-                input_comp.walk = False
-                input_comp.crouch = False
-            weapon_comp = self.ecs.get_component(entity, Weapon)
-            if weapon_comp:
-                weapon_comp.shots_remaining = weapon_comp.shots_per_mag
-                weapon_comp.reload_end = 0.0
-                weapon_comp.recoil_accum = 0.0
-            health_comp = self.ecs.get_component(entity, Health)
-            if health_comp:
-                health_comp.hp = max(1, health_comp.max_hp or 1)
-                health_comp.alive = True
-                health_comp.respawn_at = 0.0
-
-        self._last_safe_pos[pid] = (x, y, z)
-
-        # Recreate character controller if missing, else just move it
-        body = self.ecs.get_component(entity, CharacterBody) if entity is not None else None
-        if body is None or body.nodepath is None:
-            self._create_character(entity or self.ecs.create_entity(), pid, (x, y, z), yaw_rad)
-        else:
-            body.nodepath.setPos(x, y, z)
-            try:
-                body.controller.setLinearMovement(Vec3(0, 0, 0), False)
-            except Exception:
-                pass
+        self.game_mode.respawn_player(pid)
 
     # ---------- Game mechanics ----------
     def _flag_home_pos(self, fl: FlagView) -> Tuple[float, float, float]:
@@ -740,6 +608,8 @@ class LaserTagServer:
                 continue
 
             if fl.carried_by is not None:
+                continue
+            if self.game_mode.handle_flag_touch(p, team_flag, fl):
                 continue
             if fl.at_base:
                 fx, fy, fz = self._flag_home_pos(fl)
@@ -787,69 +657,7 @@ class LaserTagServer:
                     fl.x, fl.y, fl.z = fx, fy, fz
 
     def _check_captures(self):
-        to_win = int(self.cfg["server"]["captures_to_win"])
-        for team_id in (TEAM_RED, TEAM_BLUE):
-            if self.gs.teams[team_id].captures >= to_win:
-                self.gs.match_over = True
-                self.gs.winner = team_id
-
-        for pid, p in list(self.gs.players.items()):
-            if not p.alive:
-                continue
-            # Single-flag mode (neutral flag)
-            if len(self.gs.flags) == 1 and (TEAM_NEUTRAL in self.gs.flags):
-                fl = next(iter(self.gs.flags.values()))
-                if fl.carried_by != pid:
-                    continue
-                bx, by, bz = (self.mapdata.red_base if p.team == TEAM_RED else self.mapdata.blue_base)
-                if math.hypot(p.x - bx, p.y - by) <= BASE_CAPTURE_RADIUS:
-                    self.gs.teams[p.team].captures += 1
-                    fl.carried_by = None
-                    p.captures += 1
-                    # Clear carrier flag
-                    p.carrying_flag = None
-                    # Return neutral flag to center
-                    fl.at_base = True
-                    fx, fy, fz = self._flag_home_pos(fl)
-                    fl.x, fl.y, fl.z = fx, fy, fz
-                    print(f"[score] Team {'RED' if p.team==TEAM_RED else 'BLUE'} captured! -> {self.gs.teams[p.team].captures}")
-                    # Log message feed: capture
-                    try:
-                        self.messagefeed.append({
-                            "t": now(),
-                            "event": "capture",
-                            "actor": p.pid,
-                            "actor_name": p.name,
-                        })
-                    except Exception:
-                        pass
-                continue
-
-            # Legacy two-flag mode fallback
-            enemy_flag_team = TEAM_BLUE if p.team == TEAM_RED else TEAM_RED
-            fl = self.gs.flags.get(enemy_flag_team)
-            if not fl or fl.carried_by != pid:
-                continue
-            bx, by, bz = (self.mapdata.red_base if p.team == TEAM_RED else self.mapdata.blue_base)
-            if math.hypot(p.x - bx, p.y - by) <= BASE_CAPTURE_RADIUS:
-                self.gs.teams[p.team].captures += 1
-                fl.carried_by = None
-                p.captures += 1
-                p.carrying_flag = None
-                fl.at_base = True
-                fx, fy, fz = self._flag_home_pos(fl)
-                fl.x, fl.y, fl.z = fx, fy, fz
-                print(f"[score] Team {'RED' if p.team==TEAM_RED else 'BLUE'} captured! -> {self.gs.teams[p.team].captures}")
-                # Log message feed: capture
-                try:
-                    self.messagefeed.append({
-                        "t": now(),
-                        "event": "capture",
-                        "actor": p.pid,
-                        "actor_name": p.name,
-                    })
-                except Exception:
-                    pass
+        self.game_mode.check_objectives()
 
     # ---------- Lag-comp history ----------
     def _record_history(self):
@@ -1225,10 +1033,15 @@ class LaserTagServer:
         entity = self.pid_to_entity.get(victim_pid)
         pos_comp = self.ecs.get_component(entity, Position) if entity is not None else None
         health_comp = self.ecs.get_component(entity, Health) if entity is not None else None
+        death_time = now()
+        respawn_delay = float(self.cfg["server"].get("respawn_seconds", 0.0))
+        respawn_time = death_time + respawn_delay
+        if self.game_mode.respawns_locked():
+            respawn_time = float('inf')
         if health_comp:
             health_comp.alive = False
             health_comp.hp = 0
-            health_comp.respawn_at = now() + float(self.cfg["server"]["respawn_seconds"])
+            health_comp.respawn_at = respawn_time
 
         px = pos_comp.x if pos_comp else v.x
         py = pos_comp.y if pos_comp else v.y
@@ -1242,13 +1055,13 @@ class LaserTagServer:
 
         # Mark dead + schedule respawn (unchanged)
         v.alive = False
-        v.respawn_at = now() + float(self.cfg["server"]["respawn_seconds"])
+        v.respawn_at = respawn_time
 
         # --- Killfeed (unchanged) ---
         try:
             a = self.gs.players.get(attacker) if attacker is not None else None
             evt = {
-                "t": now(),
+                "t": death_time,
                 "attacker": attacker,
                 "attacker_name": (a.name if a else "World"),
                 "victim": victim_pid,
@@ -1282,7 +1095,7 @@ class LaserTagServer:
                 # Log message feed: dropped flag
                 try:
                     self.messagefeed.append({
-                        "t": now(),
+                        "t": death_time,
                         "event": "drop",
                         "actor": victim_pid,
                         "actor_name": v.name,
@@ -1532,7 +1345,10 @@ class LaserTagServer:
             match_over=self.match_over,
             winner=self.winner,
             corpse_angles=corpse_angles,
+            rounds=self.game_mode.snapshot(now_t),
             bot_debug=self.bot_debug,
+            teams_state=self.game_mode.team_snapshot(),
+            hud=self.game_mode.hud_snapshot(now_t),
         )
 
         return snapshot
@@ -1733,6 +1549,7 @@ class LaserTagServer:
 
         while True:
             t0 = now()
+            self.game_mode.pre_tick(t0)
 
             # Bots
             self._update_bots()
@@ -1775,10 +1592,13 @@ class LaserTagServer:
                 # Auto-pickup/return flags when close; no keypress required
                 self._pickup_try(p)
 
+            self.game_mode.after_flag_interactions(tick_dt)
+
             # Respawns
-            for pid, p in list(self.gs.players.items()):
-                if (not p.alive) and now() >= p.respawn_at:
-                    self.respawn_player(pid)
+            if not self.game_mode.respawns_locked():
+                for pid, p in list(self.gs.players.items()):
+                    if (not p.alive) and now() >= p.respawn_at:
+                        self.respawn_player(pid)
 
             # Safety kill-plane: if anyone somehow gets below the world, respawn them
             kill_z = -10.0


### PR DESCRIPTION
## Summary
- add a configurable round_seconds limit that ends rounds in a draw when time expires and extends the deadline when the flag is secured
- expose round countdowns via snapshots and round-mode HUD payloads so clients can show the active phase and time remaining
- render the round timer and improved round-related events on the client HUD with color warnings for low time

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ed2ab27030832a96ddd8111b1b7024